### PR TITLE
fix: should destroy child hosts even if parent is handled

### DIFF
--- a/src/StaticArrayHost.ts
+++ b/src/StaticArrayHost.ts
@@ -57,7 +57,7 @@ export class StaticArrayHost implements Host{
     destroy(parentHandle?: boolean, parentHandleComputed?: boolean) {
         if (!parentHandle) {
             removeNodesBetween(this.element, this.placeholder, true)
-            this.childHosts!.forEach(host => host.destroy(true, parentHandleComputed))
         }
+        this.childHosts!.forEach(host => host.destroy(true, parentHandleComputed))
     }
 }


### PR DESCRIPTION
npm run test -- --run

> axii@3.7.4 test
> vitest --run

 Vitest  No browser "instances" were defined. Running tests in "chromium" browser. The "browser.name" field is deprecated since Vitest 3. Read more: https://vitest.dev/guide/browser/config#browser-instances

 RUN  v3.2.3 /Users/jimnox/work/src/axii
      Coverage enabled with v8

Port 63315 is in use, trying another one...
stderr | __tests__/portal.spec.tsx > portal > should warn if reuse content
static portal content can only be rendered once. Use function content for content has reactive parts.
 ✓  chromium  __tests__/misc.spec.tsx (1 test) 16ms
 ✓  chromium  __tests__/rxListHost.spec.tsx (9 tests) 25ms
 ✓  chromium  __tests__/render.spec.tsx (17 tests) 15ms
 ✓  chromium  __tests__/portal.spec.tsx (2 tests) 42ms
 ✓  chromium  __tests__/configuration.spec.tsx (11 tests) 30ms
 ✓  chromium  __tests__/component.spec.tsx (22 tests) 122ms
 ✓  chromium  __tests__/util.spec.ts (7 tests) 1ms
 ✓  chromium  __tests__/staticArrayHost.spec.tsx (2 tests) 4ms
 ✓  chromium  __tests__/style.spec.tsx (10 tests) 5ms
 ✓  chromium  __tests__/event.spec.tsx (4 tests) 6ms
 ✓  chromium  __tests__/functionHost.spec.tsx (6 tests) 428ms
 ✓  chromium  __tests__/staticHost.spec.tsx (5 tests) 668ms
   ✓ static host render > element should remove after transition done  558ms
 ✓  chromium  __tests__/reactiveState.spec.tsx (11 tests) 999ms

 Test Files  13 passed (13)
      Tests  107 passed (107)
   Start at  22:58:18
   Duration  3.56s (transform 0ms, setup 0ms, collect 2.40s, tests 2.36s, environment 0ms, prepare 21.20s)

 % Coverage report from v8
---------------------|---------|----------|---------|---------|--------------------
File                 | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s  
---------------------|---------|----------|---------|---------|--------------------
All files            |   95.77 |    91.67 |   96.82 |   95.77 |                    
 AtomHost.ts         |     100 |    94.11 |   85.71 |     100 | 21                 
 ComponentHost.ts    |   95.67 |     88.6 |     100 |   95.67 | ...388-389,600-601 
 ContextProvider.ts  |     100 |      100 |     100 |     100 |                    
 DOM.ts              |   95.93 |    89.53 |   96.77 |   95.93 | ...428-429,458-459 
 FunctionHost.ts     |     100 |    91.66 |     100 |     100 | 22                 
 LinkedList.ts       |     100 |      100 |     100 |     100 |                    
 Portal.tsx          |     100 |      100 |     100 |     100 |                    
 RxListHost.ts       |     100 |    96.96 |     100 |     100 | 16                 
 StaticArrayHost.ts  |     100 |      100 |     100 |     100 |                    
 StaticHost.ts       |   97.92 |    90.14 |     100 |   97.92 | ...414,423-424,440 
 createHost.ts       |     100 |      100 |     100 |     100 |                    
 eventAlias.ts       |     100 |      100 |     100 |     100 |                    
 index.ts            |     100 |      100 |     100 |     100 |                    
 lazy.ts             |   11.76 |      100 |       0 |   11.76 | 5-21               
 reactiveDOMState.ts |   90.86 |    96.07 |    92.1 |   90.86 | ...435-437,439-440 
 ref.ts              |     100 |      100 |     100 |     100 |                    
 render.ts           |   96.15 |    91.66 |     100 |   96.15 | 71-72              
---------------------|---------|----------|---------|---------|--------------------