### PR TITLE
chore: expose RenderContext['pathContext']

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -79,10 +79,10 @@ export type RenderContext = {
         [k: string]: HTMLElement
     },
     context: DataContext,
+    pathContext: PathContext,
     /**
      * @internal
      */
-    pathContext: PathContext,
     createPortal: CreatePortalFn
     createRef: CreateRefFn,
     createRxRef: CreateRxRefFn,


### PR DESCRIPTION
useful for custom static node id generation from outside code space