### PR TITLE
test: reproduce fatal bugs found in framework review

### DIFF
--- a/__tests__/fatalBugs.spec.tsx
+++ b/__tests__/fatalBugs.spec.tsx
@@ -1,0 +1,273 @@
+/** @jsx createElement */
+/**
+ * 本文件用于复现代码 review 中发现的致命问题。
+ *
+ * CAUTION 每个测试断言的是【当前的错误行为】，测试通过 = bug 确实存在。
+ * 每个测试的注释中标明了正确行为应该是什么。
+ * 修复对应 bug 后，这里的断言应当反转。
+ *
+ * 编号与 review 报告一致：
+ * - BUG 1a/1b, 2, 3, 4a/4b, 5, 8 在本文件（浏览器环境）中复现；
+ * - BUG 6（仓库无法独立构建/测试：data0 只以 ../data0 兄弟目录源码 alias 存在、
+ *   不在 devDependencies 中，package.json main 指向不存在的 index.js）
+ *   由本分支对 vitest.config.ts 的修改 + devDependencies 补充 data0 所证实：
+ *   修改前在没有兄弟目录 data0 的全新 clone 上，npm install && npm test 无法运行；
+ * - BUG 7（模块加载即执行浏览器 API，Node/SSR 环境 import 即崩）在
+ *   __tests__/node/importInNode.spec.ts 中复现，需用 node 环境运行：
+ *   npx vitest run --config vitest.node.config.ts
+ */
+import {createElement, createRoot, Form, FormContext, RenderContext} from "@framework";
+import {atom, RxList, RxMap} from "data0";
+import {beforeEach, describe, expect, test} from "vitest";
+
+function nextMicrotask() {
+    return new Promise<void>(resolve => queueMicrotask(resolve))
+}
+
+describe('fatal bug reproduction', () => {
+    let rootEl: HTMLElement
+    beforeEach(() => {
+        document.body.innerHTML = ''
+        rootEl = document.createElement('div')
+        document.body.appendChild(rootEl)
+    })
+
+    /**
+     * BUG 1a: ComponentHost.render 中 root.on('attach', ...) 的返回值（退订函数）没有保存到
+     * this.deleteLayoutEffectCallback（该字段在全仓库中从未被赋值），destroy 时无法退订。
+     * 导致：渲染到 detached 容器时，组件销毁后 attach 事件仍会执行它的 layoutEffect。
+     * 正确行为：组件销毁后 layoutEffect 不应再执行（runs 应保持 0）。
+     */
+    test('BUG 1a: layoutEffect of a destroyed component still runs when root attaches later', async () => {
+        const detachedEl = document.createElement('div')
+        const root = createRoot(detachedEl)
+
+        const show = atom(true)
+        let layoutEffectRuns = 0
+
+        function Inner({}: any, {createElement, useLayoutEffect}: RenderContext) {
+            useLayoutEffect(() => {
+                layoutEffectRuns++
+            })
+            return <div>inner</div>
+        }
+
+        function App({}: any, {createElement}: RenderContext) {
+            return <div>{() => show() ? <Inner/> : null}</div>
+        }
+
+        root.render(<App/>)
+        // root 未 attach，layoutEffect 尚未执行，符合预期
+        expect(layoutEffectRuns).toBe(0)
+
+        // 在 attach 之前销毁 Inner（FunctionHost 的重算是 microtask 异步的）
+        show(false)
+        await nextMicrotask()
+        expect(detachedEl.textContent).not.toContain('inner')
+
+        // 之后容器才真正挂载，按框架约定手动派发 attach
+        document.body.appendChild(detachedEl)
+        root.dispatch('attach')
+
+        // BUG：已销毁组件的 layoutEffect 仍然被执行了。正确行为应为 0。
+        expect(layoutEffectRuns).toBe(1)
+
+        root.destroy()
+    })
+
+    /**
+     * BUG 1b: StaticHost 同样没有保存 attach 监听的退订函数（removeAttachListener 从未被赋值）。
+     * 导致：元素销毁后 attach 事件仍会把已从 DOM 移除的元素再次附加到 ref 上。
+     * 正确行为：destroy 时 ref 已被置 null，此后不应再被赋值。
+     */
+    test('BUG 1b: ref of a destroyed element is re-attached when root attaches later', async () => {
+        const detachedEl = document.createElement('div')
+        const root = createRoot(detachedEl)
+
+        const show = atom(true)
+        const refCalls: any[] = []
+
+        function App({}: any, {createElement}: RenderContext) {
+            return <div>{() => show() ? <span ref={(el: any) => refCalls.push(el)}>x</span> : null}</div>
+        }
+
+        root.render(<App/>)
+        expect(refCalls).toEqual([])
+
+        show(false)
+        await nextMicrotask()
+        // destroy 时 detachRef 被调用，ref 收到 null
+        expect(refCalls).toEqual([null])
+
+        document.body.appendChild(detachedEl)
+        root.dispatch('attach')
+
+        // BUG：attach 后，已销毁元素又被附加到 ref 上（且该元素已不在文档中）。
+        // 正确行为：refCalls 应保持 [null]。
+        expect(refCalls.length).toBe(2)
+        expect(refCalls[1]).toBeInstanceOf(HTMLElement)
+        expect((refCalls[1] as HTMLElement).isConnected).toBe(false)
+
+        root.destroy()
+    })
+
+    /**
+     * BUG 2: Root.destroy() 先执行 eventCallbacks.clear() 再 dispatch('detach')，
+     * 所有 detach 监听器都在派发前被清空。
+     * 正确行为：destroy 时 detach 监听器应被调用。
+     */
+    test('BUG 2: detach event is never dispatched on root.destroy()', () => {
+        const root = createRoot(rootEl)
+        root.render(<div>hello</div>)
+
+        let detachFired = false
+        root.on('detach', () => {
+            detachFired = true
+        })
+
+        root.destroy()
+
+        // BUG：detach 永远不会触发。正确行为应为 true。
+        expect(detachFired).toBe(false)
+    })
+
+    /**
+     * BUG 3: Form.tsx register() 的 multiple 分支存在 ASI（自动分号插入）陷阱：
+     *     values.get(name).push(instance.value)
+     *     (instances[name] as Array<FormItemInstance>).push(instance)
+     * 两行被解析为一个表达式：push(...) 的返回值被当作函数调用，抛出 TypeError。
+     * 正确行为：multiple 注册应正常把 instance 推入列表，不抛错。
+     */
+    test('BUG 3: Form register with multiple=true throws TypeError (ASI hazard)', () => {
+        const root = createRoot(rootEl)
+        let registerError: any = null
+
+        function Item({}: any, {createElement, context}: RenderContext) {
+            const formContext = context.get(FormContext)
+            try {
+                formContext.register('field', {value: atom(1), reset() {}, clear() {}}, true)
+            } catch (e) {
+                registerError = e
+            }
+            return <div>item</div>
+        }
+
+        root.render(<Form name="test" values={new RxMap<string, any>({})}><Item/></Form>)
+
+        // BUG：必然抛 TypeError（push 的返回值不是函数）。正确行为应为 registerError === null。
+        expect(registerError).toBeInstanceOf(TypeError)
+        expect(String(registerError)).toMatch(/is not a function/)
+
+        root.destroy()
+    })
+
+    /**
+     * BUG 4a: RxListHost 的 reorder 分支用 placeholder.parentElement.firstChild 作为插入锚点，
+     * 隐含假设列表独占父元素。当列表前面有兄弟节点（如标题）时，排序会把所有列表项搬到兄弟节点之前。
+     * 正确行为：排序只改变列表项之间的相对顺序，<h1> 仍应是第一个子元素。
+     */
+    test('BUG 4a: sorting an RxList that has a preceding sibling moves items before the sibling', () => {
+        const root = createRoot(rootEl)
+        const list = new RxList<number>([3, 1, 2])
+
+        function App({}: any, {createElement}: RenderContext) {
+            return <div>
+                <h1>title</h1>
+                {list.map(item => <span>{item}</span>)}
+            </div>
+        }
+
+        root.render(<App/>)
+        const container = rootEl.firstElementChild!
+        // 初始渲染顺序正确：h1 在前
+        expect(Array.from(container.children).map(el => el.tagName)).toEqual(['H1', 'SPAN', 'SPAN', 'SPAN'])
+        expect(Array.from(container.querySelectorAll('span')).map(el => el.textContent)).toEqual(['3', '1', '2'])
+
+        list.sortSelf((a, b) => a - b)
+
+        // 列表项之间的顺序是对的……
+        expect(Array.from(container.querySelectorAll('span')).map(el => el.textContent)).toEqual(['1', '2', '3'])
+        // BUG：……但所有 span 被搬到了 h1 前面。
+        // 正确行为应为 ['H1', 'SPAN', 'SPAN', 'SPAN']。
+        expect(Array.from(container.children).map(el => el.tagName)).toEqual(['SPAN', 'SPAN', 'SPAN', 'H1'])
+
+        root.destroy()
+    })
+
+    /**
+     * BUG 4b: EXPLICIT_KEY_CHANGE（list.set(0, ...)）分支同样用 parentElement.firstChild 作为
+     * index === 0 的插入锚点，新元素会被插到兄弟节点之前。
+     * 正确行为：替换后的元素应保持在 h1 之后的列表区域内。
+     */
+    test('BUG 4b: list.set(0, ...) with a preceding sibling inserts the new item before the sibling', () => {
+        const root = createRoot(rootEl)
+        const list = new RxList<number>([1, 2, 3])
+
+        function App({}: any, {createElement}: RenderContext) {
+            return <div>
+                <h1>title</h1>
+                {list.map(item => <span>{item}</span>)}
+            </div>
+        }
+
+        root.render(<App/>)
+        const container = rootEl.firstElementChild!
+        expect(Array.from(container.children).map(el => el.tagName)).toEqual(['H1', 'SPAN', 'SPAN', 'SPAN'])
+
+        list.set(0, 9)
+
+        expect(Array.from(container.querySelectorAll('span')).map(el => el.textContent)).toEqual(['9', '2', '3'])
+        // BUG：新的第 0 项被插到了 h1 前面。
+        // 正确行为应为 ['H1', 'SPAN', 'SPAN', 'SPAN']。
+        expect(container.children[0].tagName).toBe('SPAN')
+        expect(container.children[0].textContent).toBe('9')
+        expect(container.children[1].tagName).toBe('H1')
+
+        root.destroy()
+    })
+
+    /**
+     * BUG 5: setAttribute 把 onChange 别名成 input 事件后，与 onInput 在 _listeners 上撞 key，
+     * assert(listeners[eventName] === undefined) 直接抛错。
+     * 且 util.assert 的 throw 不受 __DEV__ 控制，生产构建同样会崩。
+     * 正确行为：同时监听 onChange 和 onInput 是合理写法，不应崩溃。
+     */
+    test('BUG 5: element with both onChange and onInput throws "already listened"', () => {
+        expect(() => {
+            createElement('input', {
+                onChange: () => {},
+                onInput: () => {},
+            })
+        }).toThrow(/already listened/)
+    })
+
+    /**
+     * BUG 8: 动态样式（函数/atom + 嵌套 selector）每次更新都会生成新的 CSSStyleSheet 追加到
+     * document.adoptedStyleSheets，旧的只减引用计数、不删除（源码中有 TODO 承认此问题），
+     * 要等 host destroy 才批量清理。长期存活、样式高频变化的组件会导致 stylesheet 无限累积。
+     * 正确行为：同一元素的动态样式更新应复用/回收 stylesheet，数量应保持 O(1)。
+     */
+    test('BUG 8: dynamic style with nested selector leaks one stylesheet per update', () => {
+        const root = createRoot(rootEl)
+        const color = atom('rgb(0, 0, 0)')
+
+        function App({}: any, {createElement}: RenderContext) {
+            return <div style={() => ({color: color(), '&:hover': {color: 'blue'}})}>text</div>
+        }
+
+        root.render(<App/>)
+        const countAfterRender = document.adoptedStyleSheets.length
+
+        const UPDATE_COUNT = 20
+        for (let i = 1; i <= UPDATE_COUNT; i++) {
+            color(`rgb(${i}, 0, 0)`)
+        }
+
+        const growth = document.adoptedStyleSheets.length - countAfterRender
+        // BUG：每次更新泄漏一个 stylesheet。正确行为 growth 应为 0（或至多一个小常数）。
+        expect(growth).toBe(UPDATE_COUNT)
+
+        // destroy 后才会批量清理
+        root.destroy()
+    })
+})

--- a/__tests__/node/importInNode.spec.ts
+++ b/__tests__/node/importInNode.spec.ts
@@ -1,0 +1,20 @@
+/**
+ * BUG 7 复现：reactiveDOMState.ts 在模块加载（类定义）时就执行
+ * `new ResizeObserver(...)`（RxDOMSize.globalResizeObserver 静态属性），
+ * 而 index.ts 会导出 reactiveDOMState，因此在 Node / SSR / 非浏览器测试环境中
+ * `import 'axii'` 在 import 阶段直接抛 ReferenceError。
+ *
+ * CAUTION 测试断言的是【当前的错误行为】，测试通过 = bug 确实存在。
+ * 正确行为：import 不应有浏览器 API 副作用（应惰性初始化），本测试应改为 resolves。
+ *
+ * 本文件需要在 node 环境运行（框架的默认测试环境是真实浏览器，那里 ResizeObserver 存在，
+ * 无法暴露此问题）：npx vitest run --config vitest.node.config.ts
+ */
+import {describe, expect, test} from "vitest";
+
+describe('BUG 7: importing axii outside a browser', () => {
+    test('import of the framework entry crashes with ReferenceError: ResizeObserver is not defined', async () => {
+        (globalThis as any).__DEV__ = true
+        await expect(import('../../src/index.js')).rejects.toThrow(/ResizeObserver is not defined/)
+    })
+})

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "@types/node": "^22.9.3",
     "@vitest/browser": "^3.2.4",
     "@vitest/coverage-v8": "^3.2.4",
+    "data0": "^1.13.0",
     "release-it": "^19.0.4",
     "typescript": "5.9.2",
     "vite": "^7.1.1",

--- a/prompt/output/01-overview.md
+++ b/prompt/output/01-overview.md
@@ -1,0 +1,35 @@
+# 01 架构概览与总体评价
+
+Review 对象：axii v3.9.2（commit `4249ef9`），`src/` 下 23 个文件、约 4300 行。
+
+## 核心设计
+
+axii 是一个"增量更新"的响应式前端框架，核心特点：
+
+- **无 Virtual DOM**：JSX 直接产出真实 DOM（`createElement` 返回 `HTMLElement`/`DocumentFragment`），组件函数只执行一次，永不 rerender（代码中多处 `assert(..., 'should never rerender')` 明确了这一约束）。
+- **Host 树**：渲染由一棵 Host 树驱动，`createHost`（`src/createHost.ts`）按 source 类型分派：
+  - `StaticHost` — 静态元素/Fragment，收集其中的 `unhandledChildren` / `unhandledAttr`（响应式属性走 `autorun`）；
+  - `ComponentHost` — 组件节点，负责 props 合并、AOP 配置（`$xxx:prop` DSL）、effect/layoutEffect 生命周期；
+  - `AtomHost` / `FunctionHost` — 原子值与函数子节点，分别用 `computed` / `autorun`（微任务批处理）做局部更新；
+  - `RxListHost` — 响应式列表，通过 data0 的 `manualTrack` 拿到 splice/reorder/explicit key change 的 patch 信息做增量 DOM 操作；
+  - `StaticArrayHost` / `PrimitiveHost` / `EmptyHost` — 数组、原始值、空节点。
+- **Placeholder 锚点**：每个 Host 用一个 `Comment` 节点作为在父 DOM 中的定位锚点，动态内容的插入/删除都相对 placeholder 进行。
+- **样式系统**（`StaticHost.ts` 中的 `StyleManager`）：静态样式按组件路径生成共享 class + `CSSStyleSheet`（`document.adoptedStyleSheets`）；动态样式（atom/函数）用滚动 style id；嵌套 selector、`@keyframes`、at-rules 也走 stylesheet。
+- **组件 AOP**：通过 `as` 命名内部元素、`$name:prop` / `$name:prop_` / `$name:_use` / `$name:_props` / `$name:_children` / `prop:` / `$self:` 等字符串 DSL，外部可以覆写/合并组件内部任意命名元素的 props 甚至整个元素，配合 `boundProps` / `postBoundProps` 实现样式-逻辑分离。
+- **响应式 DOM 状态**（`reactiveDOMState.ts`）：`RxDOMRect` / `RxDOMSize` / `RxDOMFocused` / `RxDOMDragState` 等把 DOM 位置、尺寸、焦点、拖拽包装成响应式数据。
+
+## 总体评价
+
+**方向性判断：架构自洽、没有致命的设计缺陷。**
+
+- "组件只执行一次 + 响应式数据绑定 DOM"的心智模型简单，且实现忠实于这个模型（没有 diff、没有隐藏的 rerender 路径）。
+- 增量更新路径（`RxListHost` 的 splice patch、`AtomHost` 的文本节点复用、`StaticHost` 的属性级 autorun）确实做到了理论最小 DOM 变更。
+- Host 抽象的职责边界清楚，`parentHandle` / `parentHandleComputed` 两个 destroy 参数是为了让父级批量清理时避免子级重复操作，设计合理（尽管透传有遗漏，见改进项）。
+
+**但实现层面的问题密度偏高**：8 个致命问题里有 5 个（BUG 1/2/3/4/5）属于"写了但没接上"或"两行代码顺序反了"这类低级疏漏，而且都落在测试盲区里（`Form.tsx` 被排除在 coverage 之外、reorder 无任何用例、detached root 场景无用例）。这说明测试策略比代码本身更需要补强——覆盖率数字（README 徽章）因为 exclude 配置而虚高。
+
+详见：
+
+- [02-fatal-issues.md](./02-fatal-issues.md) — 致命问题详述
+- [03-improvements.md](./03-improvements.md) — 显著改进项
+- [04-reproduction-report.md](./04-reproduction-report.md) — 复现验证报告

--- a/prompt/output/02-fatal-issues.md
+++ b/prompt/output/02-fatal-issues.md
@@ -1,0 +1,175 @@
+# 02 致命问题（8 项）
+
+以下问题会在真实场景中直接崩溃或产生错误行为。**全部 8 项都已经过测试验证确实存在**，复现细节见 [04-reproduction-report.md](./04-reproduction-report.md)。
+
+行号基于 commit `4249ef9`（v3.9.2）。
+
+---
+
+## BUG 1：`attach` 事件的退订句柄从未被赋值 → 已销毁组件的 layoutEffect / ref 仍会执行
+
+**位置**：`src/ComponentHost.ts`、`src/StaticHost.ts`
+
+`ComponentHost` 和 `StaticHost` 都定义了退订字段，`destroy()` 里也调用了它们，但**两处都没有保存 `root.on()` 的返回值**：
+
+```ts
+// src/ComponentHost.ts L467-471
+if (this.pathContext.root.attached) {
+    this.runLayoutEffect()
+} else {
+    this.pathContext.root.on('attach', this.runLayoutEffect, {once: true})   // 返回值被丢弃
+}
+```
+
+- `ComponentHost.deleteLayoutEffectCallback`（L91 声明，L507 调用）全仓库没有任何赋值语句；
+- `StaticHost.removeAttachListener`（L412 声明，L539 调用）同样从未赋值（注册点在 L453）。
+
+**后果**：把树渲染到 detached 容器（或 Portal 到未连接节点）时，若某组件在 root attach 之前被销毁（例如 `FunctionHost` 的一次微任务重渲染把它换掉了），attach 触发时：
+
+- 已销毁组件的 `runLayoutEffect` 仍会运行——对已移除的 DOM 执行 layoutEffect；
+- 已销毁元素会被重新附加到 ref 上（且该元素 `isConnected === false`）；
+- root 永不 attach 时监听器永久泄漏。
+
+**修复**：一行改动，`this.deleteLayoutEffectCallback = this.pathContext.root.on(...)`（StaticHost 同理）。
+
+---
+
+## BUG 2：`Root.destroy()` 先清空回调再派发 `detach` → detach 事件永远不会触发
+
+**位置**：`src/render.ts` L52-57
+
+```ts
+destroy() {
+    eventCallbacks.clear()          // 先清空了所有监听器
+    root.dispatch('detach')         // 派发时已经没有任何监听器了
+    root.host?.destroy()
+    root.attached = false
+},
+```
+
+**后果**：任何依赖 `detach` 事件做清理的下游代码（组件库、路由、Portal 内容）都会静默失效。
+
+**修复**：两行顺序对调。
+
+---
+
+## BUG 3：`Form` 多值注册路径必然抛 TypeError（ASI 陷阱）
+
+**位置**：`src/Form.tsx` L53-54
+
+```ts
+values.get(name).push(instance.value)
+(instances[name] as Array<FormItemInstance>).push(instance)
+```
+
+第二行以 `(` 开头，JS 不会自动插入分号，这两行被解析为一个表达式：
+
+```ts
+values.get(name).push(instance.value)(instances[name] ...).push(instance)
+```
+
+`push` 的返回值（数字）被当作函数调用，**任何 `multiple: true` 的 FormItem 注册时直接抛 `TypeError: ... is not a function`**。
+
+因为 `values` 是 `RxMap<string, any>`，`get` 返回 `any`，TypeScript 检查不出来；`Form.tsx` 又恰好被排除在 coverage 之外（`vitest.config.ts` coverage.exclude），所以一直没被测出来。
+
+**修复**：补一个分号（或把两行写法改掉）。
+
+---
+
+## BUG 4：`RxListHost` 的 reorder / 显式 key 变更假设列表独占父元素
+
+**位置**：`src/RxListHost.ts`
+
+两处都用 `host.placeholder.parentElement!.firstChild` 作为插入锚点：
+
+```ts
+// L86-92，reorder 分支
+} else if(method === 'reorder') {
+    const placeholders = ...
+    insertBefore(placeholderFragment, host.placeholder.parentElement!.firstChild! as HTMLElement)
+```
+
+```ts
+// L109-113，EXPLICIT_KEY_CHANGE 分支，index === 0 时
+if (index === 0) {
+    insertBefore(host.hosts!.raw.at(index)!.placeholder, host.placeholder.parentElement!.firstChild! as HTMLElement)
+```
+
+**后果**：只要列表**不是父元素的第一个孩子**——`<div><h1/>{list.map(...)}</div>` 这种再常见不过的结构——
+
+- `list.sortSelf(...)`（reorder）会把**所有列表项搬到 `<h1>` 前面**；
+- `list.set(0, ...)`（explicit key change）会把新的第 0 项插到 `<h1>` 前面。
+
+正确的锚点应该是列表自身区域的起点（当前第一个 item 的 element / 原有 placeholder 位置），而不是父元素的 firstChild。测试里没有任何 reorder/sort 用例，这条路径完全没被覆盖。
+
+---
+
+## BUG 5：同一元素上 `onChange` + `onInput` 直接抛错，且生产构建同样会抛
+
+**位置**：`src/DOM.ts` L110-127
+
+```ts
+if (eventName === 'change') eventName = 'input'   // onChange 被别名成 input
+...
+assert(listeners?.[eventName] === undefined, `${name} already listened`);
+```
+
+`onChange` 别名成 `input` 后与用户同时写的 `onInput` 在 `_listeners` 上撞 key，`assert` 直接 throw。
+
+两个加重因素：
+
+1. `util.ts` 的 `assert` 只有 `debugger` 受 `__DEV__` 控制，**throw 在生产构建同样生效**——生产环境一样崩；
+2. 同理，想通过再次 `setAttribute` 把事件置空来解绑也会命中这个 assert（先 `removeEventListener` 再撞 assert）。
+
+---
+
+## BUG 6：仓库无法独立构建 / 测试；`package.json` 的 `main` 指向不存在的文件
+
+**位置**：`vitest.config.ts`（原 `vite.config.ts` 同源配置）、`package.json`
+
+1. 测试配置把 `data0` alias 到 `../data0/src/index.ts`（**兄弟目录的源码 checkout**），而 `data0` 只在 `peerDependencies` 里、不在 `devDependencies`。新 clone 下来 `npm install && npm test` 必挂——本次 review 环境中实测确认（无 `node_modules`、无 `../data0` 时测试完全无法运行）。CI / 外部贡献者的门槛直接被挡死。
+2. `"main": "index.js"` 指向根目录不存在的文件。现代打包器走 `exports` 字段没事，但老工具链（旧版 Jest / metro / node 解析）会解析 `main` 而失败。应指向 `./dist/axii.umd.cjs`，并顺手补 `sideEffects` 声明。
+
+**本 review 分支已附带部分修复**：`data0@1.13.0` 加入 devDependencies（在 peer 范围 `^1.10.0` 内）；alias 改为"兄弟目录存在则用源码、否则回退到 npm 安装的包"。`main` 字段未改动（留给维护者决策）。
+
+---
+
+## BUG 7：模块加载即执行浏览器 API → 在 Node / SSR 环境 `import 'axii'` 直接崩
+
+**位置**：`src/reactiveDOMState.ts` L196-197
+
+```ts
+export class RxDOMSize extends RxDOMState<HTMLElement|Window, SizeObject>{
+    static resizeTargetToState= new WeakMap<HTMLElement, Atom<SizeObject|null>>()
+    static globalResizeObserver = new ResizeObserver(entries => { ... })   // 类定义时即执行
+```
+
+`index.ts` 会 `export * from './reactiveDOMState.js'`，因此 **import 框架入口的瞬间**就会执行 `new ResizeObserver(...)`——Node 里不存在这个全局，直接 `ReferenceError: ResizeObserver is not defined`。
+
+**后果**：即使不做 SSR，任何非浏览器环境（node 单测、工具脚本、构建期预渲染）都无法引入 axii。
+
+**修复**：惰性初始化（首次 `listen()` 时创建 observer）。
+
+---
+
+## BUG 8：动态样式的 StyleSheet 无上限累积（代码内 TODO 自认）
+
+**位置**：`src/StaticHost.ts` `StyleManager.update`，L268-277
+
+```ts
+if (shouldUseRollingStyleId) {
+    const lastStyleSheetId = `${so.styleSheetIdWithIndex}I${styleItorNum - 1}`
+    el.classList.remove(lastStyleSheetId)
+    // 更新引用计数，但归零时并不会立即清除 stylesheet，因为它可能还被 cloneNode 用到
+    // 如果现在清除，cloneNode 的样式会瞬间失效
+    // TODO: 如果一个组件一直不 destroy，这里就会一直不清除 stylesheet
+    // 后面可以考虑加上一个长度为 2 的 buffer
+    this.updateRefCount(lastStyleSheetId, -1)
+}
+```
+
+每次动态样式（atom / 函数 style，且包含嵌套 selector 而必须走 stylesheet）更新，都会以新的滚动 id 生成一个新 `CSSStyleSheet` 追加进 `document.adoptedStyleSheets`；旧的只减引用计数、**不从 adoptedStyleSheets 中移除**，要等 host destroy 才批量清理。
+
+**后果**：一个长期存活、样式高频变化的组件（拖拽、动画驱动、鼠标跟随）会让 adoptedStyleSheets 涨到成千上万，样式匹配开销线性恶化直至页面卡死。实测每更新一次泄漏恰好一个 stylesheet（20 次更新 → +20）。这是框架"高性能增量更新"卖点路径上的性能定时炸弹。
+
+**修复方向**：按 TODO 所说加长度为 2 的双缓冲；或对同一 el 复用同一个 sheet 做 `replaceSync`。

--- a/prompt/output/03-improvements.md
+++ b/prompt/output/03-improvements.md
@@ -1,0 +1,86 @@
+# 03 显著值得改进的地方
+
+以下问题不至于"致命"，但明显值得处理。分为"正确性 / 健壮性"与"设计 / 可维护性"两类。行号基于 commit `4249ef9`（v3.9.2）。
+
+## 正确性 / 健壮性
+
+### 1. `mergeProp` 的 `'classname'` 拼写错误 + `startsWith('on')` 误伤
+
+`src/ComponentHost.ts` L42：
+
+```ts
+if(originValue && (key.startsWith('on') || key === 'ref'|| key==='style' || key==='classname' || key==='class')) {
+```
+
+- JSX 用的是 `className`（驼峰），小写 `'classname'` 永远匹配不上——AOP 合并 className 时实际是"覆盖"而非注释所暗示的"合并"。
+- `key.startsWith('on')` 会误伤 `once`、`onlyIcon` 这类普通 prop，把它们错误地 concat 成数组。应改用 `/^on[A-Z]/`。
+
+### 2. `style={null}` 会崩
+
+`isValidAttribute` 判 `null` 为 unhandled attr（`typeof null === 'object'` 且不是合法 style 对象），走到 `StyleManager.update` 后 `isDynamicProp(null)` 执行 `null['__dynamic']` 抛 TypeError。条件样式 `style={cond ? {...} : null}` 是很自然的写法。
+
+### 3. `checked` 只写 attribute 不写 property
+
+`src/DOM.ts` L208-214：`checked` 分支只 `setAttribute('checked', ...)`。用户点过 checkbox 之后（dirty state），attribute 不再影响显示，响应式 `checked` 会失灵。相邻的 `value` 分支就同时写了 property + attribute，`checked` 应当对齐。
+
+### 4. `FunctionHost` 销毁与微任务重算存在竞态
+
+`src/FunctionHost.ts` L45-52：`queueMicrotask(recompute)` 已入队后若 host 被 destroy，微任务仍会执行 `recompute()`。是否安全完全取决于 data0 对已 stop 的 autorun 的容错。应在回调里检查销毁标志。
+
+### 5. `StaticHost.destroy` 的异步分支没有错误兜底；离场动画标记不透传
+
+- `removeElements()` 是 fire-and-forget 的 async（等待 transition/animation 后才删 DOM）。等待期间若父节点被其他路径清掉，`removeNodesBetween` 会 throw 成 unhandled rejection。
+- `RxListHost` 的"整段 `replaceChildren` 快速删除"只检查直接子 host 的 `forceHandleElement`；`ComponentHost` 不会向内层 `StaticHost` 透传这个标记，**包在组件里的离场动画会被静默跳过**。
+
+### 6. `createHTMLOrSVGElement` 里 itemConfig 合并用的是 `rawProps` 而不是 `finalProps`
+
+`src/ComponentHost.ts` L207-211：当某元素同时有 `$self:` / `prop:` 前缀 props 又被外部 AOP 配置（`thisItemConfig.props` 存在）时，`separateProps` 的处理结果被丢弃，`prop:` / `$self:` 键以原始形态混回 props。
+
+### 7. `createRoot(element, parentContext)` 原地改写传入 context 的 `root` 字段
+
+`src/render.ts` L79：`pathContext.root = root`。Portal 传入的是父组件自己的 `pathContext`，被改写后该组件的 `pathContext.root` 指向了内层 root。目前行为碰巧可用，但这是隐蔽的共享可变状态，createRoot 内部应当 clone。
+
+### 8. `Root.render` 可重入无保护
+
+连调两次会往容器追加两棵树，应有 assert 或幂等保护。
+
+## 设计 / 可维护性
+
+### 9. 没有任何错误处理机制
+
+组件 render 抛错会让 Host 树停在半渲染状态；`FunctionHost` 的 autorun 重算抛错后该区域永久失效。作为定位"大型应用基础设施"的框架，至少需要 error boundary 或全局 onError 钩子。
+
+### 10. AOP 字符串 DSL 拼错即静默失效
+
+`$item:prop`、`$item:prop_`、`$self:`、`prop:`、`_use` / `_props` / `_children` 这套机制是框架核心卖点，但没有任何 dev 警告；`parseItemConfigFromProp` 里唯一的 assert 报错信息还用错了变量（打印 `itemName` 而非非法的 `itemProp`）。建议 `__DEV__` 下对未命中的 `as` 名称、未知 config 项给出警告。
+
+### 11. 死代码
+
+- `src/common.ts` 整个文件没有被 `index.ts` 导出，内容与 `reactiveDOMState.ts` 大面积重复（连 `ModalContext` 都定义了两份）；
+- `ComponentHost.reusedNodes`（L72）声明后从未使用；
+- `StaticHost.parentElement`（L411）声明后从未使用；
+- `ComponentHost.render` 里 `this.props` 被连续赋值两次（L439、L444）。
+
+### 12. propTypes 半成品
+
+- `shapeOf.check` 恒返回 `true`；`arrayOf` / `shapeOf` 的 stringify/parse 是空 TODO；
+- `normalizePropsByPropTypes` 里 `coerce?.(v) || v` 会把 coerce 的合法 falsy 返回值吞掉；
+- `propTypes.ts` 被排除在 coverage 之外。
+
+### 13. `insertBefore` 的区间搬移是逐节点递归
+
+`src/DOM.ts` L476-490：递归深度等于节点数，长列表 reorder 时有栈溢出风险，改成循环即可。
+
+### 14. 测试盲区
+
+- reorder / sort 无任何用例（正是致命问题 BUG 4 漏网的原因）；
+- `Form.tsx`、`propTypes.ts`、`common.ts` 被 coverage 排除（BUG 3 因此漏网）；
+- README 徽章展示的覆盖率因 exclude 配置而虚高。
+
+### 15. 其他小项
+
+- `lazy.ts` 的 `LazyComonent` 拼写错误（cosmetic）；`atom` 直接存组件函数的写法依赖 data0 对函数值的处理语义，值得确认；
+- `eventProxy`（`src/DOM.ts` L75-78）对数组 listener 用 `forEach`，吞掉了返回值；
+- `assert` 的报错字符串在生产 bundle 里全部保留，可换成 dev-only 详细信息 + 生产短码；
+- `package.json` 缺 `sideEffects`、`repository`、`description` 等元数据；
+- 动态事件绑定不可能（`isValidAttribute` 对 `on*` 恒真，事件永远不走 autorun），属于设计限制，但值得在文档中明示。

--- a/prompt/output/04-reproduction-report.md
+++ b/prompt/output/04-reproduction-report.md
@@ -1,0 +1,66 @@
+# 04 致命问题测试复现报告
+
+本报告记录 [02-fatal-issues.md](./02-fatal-issues.md) 中 8 个致命问题的验证方法与结果。
+
+**结论：8 个致命问题全部确认存在，没有误报。**
+
+## 验证方法
+
+复现测试在分支 `cursor/reproduce-fatal-bugs-0b0a` 上（PR [axiijs/axii#11](https://github.com/axiijs/axii/pull/11)），文件：
+
+- `__tests__/fatalBugs.spec.tsx` — 浏览器环境（vitest browser mode + Playwright chromium），复现 BUG 1a/1b、2、3、4a/4b、5、8，共 8 个测试；
+- `__tests__/node/importInNode.spec.ts` + `vitest.node.config.ts` — node 环境，复现 BUG 7（默认测试环境是真实浏览器，`ResizeObserver` 存在，暴露不了这个问题）；
+- BUG 6 由测试环境搭建过程本身证实（见下）。
+
+**约定**：每个测试断言的是【当前的错误行为】，测试通过 = bug 确实存在。每个测试的注释中写明了正确行为应该是什么；修复对应 bug 后，断言应当反转，测试即转为回归测试。
+
+## 运行方式
+
+```bash
+npm install
+npx playwright install chromium
+
+# 浏览器环境复现（BUG 1/2/3/4/5/8）
+npx vitest run __tests__/fatalBugs.spec.tsx --coverage.enabled=false
+
+# node 环境复现（BUG 7）
+npx vitest run --config vitest.node.config.ts
+
+# 全量回归（确认没有破坏既有测试）
+npx vitest run --coverage.enabled=false
+```
+
+## 逐项结果
+
+| Bug | 测试 | 观测到的错误行为 | 结果 |
+| --- | --- | --- | --- |
+| 1a | `layoutEffect of a destroyed component still runs when root attaches later` | detached 容器中组件销毁后，`root.dispatch('attach')` 仍执行了它的 layoutEffect（`layoutEffectRuns === 1`，应为 0） | ✅ 复现 |
+| 1b | `ref of a destroyed element is re-attached when root attaches later` | 元素销毁时 ref 已收到 `null`，attach 后 ref 又被赋值为已脱离文档的元素（`isConnected === false`） | ✅ 复现 |
+| 2 | `detach event is never dispatched on root.destroy()` | `root.on('detach', spy)` 后 `destroy()`，spy 未被调用 | ✅ 复现 |
+| 3 | `Form register with multiple=true throws TypeError (ASI hazard)` | `register('field', instance, true)` 抛 `TypeError: ... is not a function` | ✅ 复现 |
+| 4a | `sorting an RxList that has a preceding sibling moves items before the sibling` | `<div><h1/>{list}</div>` 结构下 `list.sortSelf()` 后子元素顺序变为 `['SPAN','SPAN','SPAN','H1']`（应为 `['H1','SPAN','SPAN','SPAN']`） | ✅ 复现 |
+| 4b | `list.set(0, ...) with a preceding sibling inserts the new item before the sibling` | `list.set(0, 9)` 后新元素出现在 `<h1>` 之前 | ✅ 复现 |
+| 5 | `element with both onChange and onInput throws "already listened"` | `createElement('input', {onChange, onInput})` 直接抛 `already listened` | ✅ 复现 |
+| 6 | （环境搭建过程证实，非 spec） | 全新环境无 `../data0` 兄弟目录时，`npm install && npm test` 无法运行：`data0` 被硬编码 alias 到不存在的路径，且不在 devDependencies | ✅ 证实 |
+| 7 | `import of the framework entry crashes with ReferenceError` (node env) | node 环境 `import 'src/index'` 在 import 阶段 reject：`ReferenceError: ResizeObserver is not defined` | ✅ 复现 |
+| 8 | `dynamic style with nested selector leaks one stylesheet per update` | 动态嵌套样式更新 20 次，`document.adoptedStyleSheets.length` 恰好增长 20 | ✅ 复现 |
+
+## 环境修复说明（BUG 6 的附带处理）
+
+为了让复现测试能在独立 clone 上运行，本分支做了两处最小改动：
+
+1. `package.json`：`devDependencies` 增加 `data0@1.13.0`（在 peerDependencies `^1.10.0` 范围内）；
+2. `vitest.config.ts`：`data0` alias 改为"`../data0` 兄弟目录存在则使用其源码（保持原作者的开发方式），否则回退到 npm 安装的 data0"。
+
+`package.json` 的 `"main": "index.js"` 指向不存在文件的问题**未**在本分支修复，留给维护者决策。
+
+## 回归确认
+
+全量测试套件在改动后全部通过：
+
+```
+Test Files  14 passed (14)
+     Tests  121 passed (121)   # 113 个既有测试 + 8 个新增复现测试
+```
+
+node 环境套件：1 passed (1)。

--- a/prompt/output/README.md
+++ b/prompt/output/README.md
@@ -1,0 +1,24 @@
+# Axii 框架深度 Review 文档
+
+本目录是对 axii 框架（v3.9.2，commit `4249ef9`）进行深度 code review 的产出文档。
+
+## 目录
+
+| 文档 | 内容 |
+| --- | --- |
+| [01-overview.md](./01-overview.md) | 架构概览与总体评价 |
+| [02-fatal-issues.md](./02-fatal-issues.md) | 致命问题（8 项，全部经测试验证确实存在） |
+| [03-improvements.md](./03-improvements.md) | 显著值得改进的地方（正确性 / 健壮性 / 设计 / 可维护性） |
+| [04-reproduction-report.md](./04-reproduction-report.md) | 致命问题的测试复现报告（验证方法、结果、运行方式） |
+
+## 结论摘要
+
+- **架构方向没有致命缺陷**：无 VDOM、组件函数只执行一次、Host 树 + Comment placeholder 锚点、基于 data0 的增量更新，这套设计是自洽且清晰的。
+- **实现层面存在 8 个致命问题**，会在真实场景中直接崩溃或产生错误行为，其中多个是"清理句柄声明了但从未赋值"、"ASI 分号陷阱"这类可以一两行修掉的疏漏。
+- 全部 8 个致命问题都已在 `__tests__/fatalBugs.spec.tsx` 和 `__tests__/node/importInNode.spec.ts` 中复现验证（BUG 6 由测试环境搭建过程本身证实），**没有误报**。
+
+## 建议的处理顺序
+
+1. **一两行即可修复**：BUG 1（两处退订赋值）、BUG 2（destroy 顺序）、BUG 3（Form 加分号）、`mergeProp` 的 `'classname'` 拼写。
+2. **影响真实用户的行为错误**：BUG 4（reorder 锚点）、BUG 5（事件别名冲突）、BUG 8（stylesheet 累积）。
+3. **工程基础**：BUG 6（data0 依赖，让仓库可独立测试，本 review 分支已附带修复）、BUG 7（浏览器 API 惰性初始化）。

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,5 +1,10 @@
 import {fileURLToPath, URL } from 'url'
+import {existsSync} from 'fs'
 import tsconfigPaths from 'vite-tsconfig-paths'
+
+// Use the sibling data0 checkout when available (original dev setup),
+// otherwise fall back to the npm-installed data0 so the repo is self-contained.
+const siblingData0 = fileURLToPath(new URL('../data0/src/index.ts', import.meta.url))
 
 export default {
   esbuild: {
@@ -12,7 +17,7 @@ export default {
   resolve: {
     alias: {
       '@framework': fileURLToPath(new URL('./src/index.ts', import.meta.url)),
-      'data0': fileURLToPath(new URL('../data0/src/index.ts', import.meta.url))
+      ...(existsSync(siblingData0) ? {'data0': siblingData0} : {})
     }
   },
   server: {
@@ -23,6 +28,8 @@ export default {
   },
   plugins: [tsconfigPaths()],
   test: {
+    // node-environment specs (run via vitest.node.config.ts) can't run in the browser
+    exclude: ['**/node_modules/**', '__tests__/node/**'],
     pool:'threads',
     poolOptions: {
       threads: {

--- a/vitest.node.config.ts
+++ b/vitest.node.config.ts
@@ -1,0 +1,29 @@
+import {fileURLToPath, URL} from 'url'
+import {existsSync} from 'fs'
+import tsconfigPaths from 'vite-tsconfig-paths'
+
+// Node-environment test config, used to reproduce bugs that the browser-based
+// default config cannot expose (e.g. module-load-time usage of browser-only APIs).
+// Run with: npx vitest run --config vitest.node.config.ts
+const siblingData0 = fileURLToPath(new URL('../data0/src/index.ts', import.meta.url))
+
+export default {
+  esbuild: {
+    jsxFactory: 'createElement',
+    jsxFragment: 'Fragment',
+  },
+  define: {
+    __DEV__: true,
+  },
+  resolve: {
+    alias: {
+      '@framework': fileURLToPath(new URL('./src/index.ts', import.meta.url)),
+      ...(existsSync(siblingData0) ? {'data0': siblingData0} : {})
+    }
+  },
+  plugins: [tsconfigPaths()],
+  test: {
+    environment: 'node',
+    include: ['__tests__/node/**/*.spec.ts'],
+  },
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

This PR contains the full output of a deep review of the framework:

1. **Review documents** under `prompt/output/` (in Chinese) covering the architecture assessment, all fatal issues, and improvement suggestions.
2. **Test cases reproducing every fatal bug.** Each test asserts the *current buggy behavior*, so a passing test proves the bug exists. Comments in each test state the correct behavior; after fixing a bug, the corresponding assertions should be inverted.

## Review documents (`prompt/output/`)

- `README.md` — index and conclusion summary
- `01-overview.md` — architecture overview and overall assessment
- `02-fatal-issues.md` — the 8 fatal issues in detail
- `03-improvements.md` — significant improvement items (correctness/robustness + design/maintainability)
- `04-reproduction-report.md` — verification method, per-bug results, how to run

## Reproduced bugs

`__tests__/fatalBugs.spec.tsx` (browser environment, 8 tests):

- **BUG 1a/1b** — `ComponentHost.deleteLayoutEffectCallback` and `StaticHost.removeAttachListener` are declared and called in `destroy()`, but the return value of `root.on('attach', ...)` is never assigned to them. When rendering into a detached container, components destroyed before the root attaches still run their `layoutEffect` and re-attach refs to removed DOM once `attach` fires.
- **BUG 2** — `Root.destroy()` calls `eventCallbacks.clear()` *before* `dispatch('detach')`, so `detach` listeners never fire.
- **BUG 3** — `Form.register()` with `multiple: true` always throws `TypeError` due to an ASI hazard: a line starting with `(` merges with the previous `push(...)` call into one expression (`Form.tsx` lines 53–54).
- **BUG 4a/4b** — `RxListHost`'s `reorder` and explicit-key-change (index 0) branches use `placeholder.parentElement.firstChild` as the insertion anchor, assuming the list is the sole content of its parent. With a preceding sibling (e.g. `<h1>` before the list), `sortSelf()` / `list.set(0, ...)` move list items *before* the sibling.
- **BUG 5** — `setAttribute` aliases `onChange` to the `input` event, colliding with `onInput` on the same element and hitting the `already listened` assert (which also throws in production builds).
- **BUG 8** — dynamic styles with nested selectors create a new `CSSStyleSheet` in `document.adoptedStyleSheets` per update; old sheets are only ref-count-decremented, never removed until host destroy (acknowledged by a TODO in `StaticHost.ts`). The test shows 20 updates → 20 leaked stylesheets.

`__tests__/node/importInNode.spec.ts` (node environment, run via `npx vitest run --config vitest.node.config.ts`):

- **BUG 7** — `RxDOMSize.globalResizeObserver` runs `new ResizeObserver(...)` at module load, and `index.ts` re-exports `reactiveDOMState`, so importing the framework entry in Node/SSR crashes with `ReferenceError: ResizeObserver is not defined`. The default browser-based test setup cannot expose this, hence the separate node config.

## BUG 6: repo was not runnable on a standalone clone

Verified and fixed as part of setting up this PR: `vitest.config.ts` hard-aliased `data0` to a `../data0` sibling source checkout, and `data0` was only a peer dependency — a fresh `git clone && npm install && npm test` could not run at all.

- Added `data0@1.13.0` to `devDependencies` (within the `^1.10.0` peer range).
- The alias now falls back to the npm-installed `data0` when the sibling checkout is absent, preserving the original dev setup when it exists.

Not covered by tests (noted in the review, no code change here): `package.json` `"main": "index.js"` points to a non-existent file.

## Test results

- Full browser suite: **14 files, 121 tests passed** (113 pre-existing + 8 new reproductions).
- Node suite: **1 test passed**.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c457dfe6-11b0-4fd6-ba90-dd4995800b0a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c457dfe6-11b0-4fd6-ba90-dd4995800b0a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

