### PR TITLE
docs: add Cursor Cloud dev environment setup notes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,15 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+`axii` is a frontend framework **library**, not a standalone app. `npm start` launches Vite but there is no root `index.html`, so it does not serve a meaningful page — the way to "run" this repo is its test suite, and the sibling `benchmark` repo is the runnable UI that consumes it.
+
+Services / commands (see `package.json` scripts):
+- Tests run in a **real browser** via Vitest + Playwright (chromium, headless). One-shot: `npx vitest run` (the default `vitest.config.ts` always enables browser mode + coverage). `npm test` starts watch mode.
+- Node-environment tests (a separate config): `npx vitest run --config vitest.node.config.ts`.
+- Build: `npm run build` → emits `dist/` (bundle + `.d.ts`). The sibling `benchmark` repo imports `../axii/dist/axii.js` by default, so **rebuild after changing `src/` for the benchmark to pick up changes** (or run the benchmark with `AXII_BENCHMARK_SOURCE_AXII=true` to consume `src/` directly).
+
+Gotchas:
+- Browser tests need the Playwright chromium browser **and** its system libraries. The update script runs `npx playwright install chromium`, but the OS libraries (`--with-deps`, needs sudo) are part of the base image, not the update script.
+- There is no lint script. `npx tsc --noEmit -p tsconfig.json` reports **pre-existing** errors in `__tests__/*.typespec.tsx` and a few spec files; it is not wired into `build` (which uses `vite-plugin-dts`) or CI. Rely on `npm run build` + `npx vitest run` as the quality gates.
+- `data0` (the reactive core) resolves from the npm-installed package unless a sibling `../data0/src` checkout exists (see `vite.config.ts`); no sibling checkout is present here.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up the development environment for the `axii` framework library and documents durable, non-obvious setup guidance for future Cursor Cloud agents.

- Adds `AGENTS.md` with a `## Cursor Cloud specific instructions` section covering how to test (browser-based Vitest + Playwright), the node-env test config, building `dist/` (consumed by the sibling `benchmark` repo), and gotchas (no lint script, pre-existing `tsc` errors in test files).

## Environment verified

- `npm install` — installs dependencies
- `npm run build` — builds `dist/` (bundle + `.d.ts`)
- `npx playwright install chromium` — browser for tests
- `npx vitest run` — 153 browser tests pass
- `npx vitest run --config vitest.node.config.ts` — 5 node tests pass

No application/library source was modified.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5234cc76-1c37-454e-91b6-f33882b15c98"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5234cc76-1c37-454e-91b6-f33882b15c98"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

