### PR TITLE
perf: cut retained memory per binding (-30%) and per component (-57%) without hurting speed

### DIFF
--- a/src/AtomHost.ts
+++ b/src/AtomHost.ts
@@ -1,4 +1,4 @@
-import {Atom} from "data0";
+import {Atom, ReactiveEffect} from "data0";
 import {Host, PathContext} from "./Host";
 import {trackHostDestroyed, trackLightBindingCreated, trackLightBindingDestroyed} from "./retainedObjectDiagnostics.js";
 import {LightBindingEffect} from "./LightBindingEffect.js";
@@ -12,11 +12,18 @@ function stringValue(v: any) {
 }
 /**
  * @internal
+ *
+ * CAUTION AtomHost 自己就是绑定 effect（继承 LightBindingEffect），不再为每个 atom 文本
+ *  单独分配一个 effect 对象 + update 闭包。长列表里每行的文本绑定都会经过这里，
+ *  合并后每行少一个对象和一个闭包的常驻内存。
  */
-export class AtomHost implements Host{
-    effect?: LightBindingEffect
-    element: Text|Comment = this.placeholder
+export class AtomHost extends LightBindingEffect implements Host{
+    element: Text|Comment
     constructor(public source: Atom, public placeholder:Comment|Text, public pathContext: PathContext) {
+        super(undefined, pathContext.skipIndicator as {skip: boolean}|undefined)
+        this.element = placeholder
+        // Host 的生命周期由宿主树显式管理，不能被创建时的 collect frame/父 effect 接管
+        this.detachFromCreationContext()
     }
     get parentElement() {
         // CAUTION 这里必须用 parentNode，因为可能是在数组下，这个父节点是 staticArrayHost 创建的 frag
@@ -43,32 +50,35 @@ export class AtomHost implements Host{
         }
     }
 
-    render(): void {
-        // CAUTION skipIndicator 是给富文本编辑器 contenteditable 来跳过 dom 变换的
-        this.effect = new LightBindingEffect(() => {
-            // CAUTION 诊断关闭（生产环境）时不分配 trace frame 对象，文本更新是最热的路径之一
-            if (isAxiiDiagnosticsEnabled()) {
-                withReactiveTrace({
-                    type: 'atom-text',
-                    operation: 'update-text',
-                    hostType: 'AtomHost',
-                    elementPath: this.pathContext.elementPath,
-                    source: this.pathContext.debugSource,
-                }, () => {
-                    this.replace(this.source())
-                })
-            } else {
+    // LightBindingEffect 触发时的回调（以原型方法提供，替代构造器闭包）
+    update() {
+        // CAUTION 诊断关闭（生产环境）时不分配 trace frame 对象，文本更新是最热的路径之一
+        if (isAxiiDiagnosticsEnabled()) {
+            withReactiveTrace({
+                type: 'atom-text',
+                operation: 'update-text',
+                hostType: 'AtomHost',
+                elementPath: this.pathContext.elementPath,
+                source: this.pathContext.debugSource,
+            }, () => {
                 this.replace(this.source())
-            }
-        }, this.pathContext.skipIndicator)
-        trackLightBindingCreated(this.effect, 'AtomTextBinding')
-        this.effect.run()
+            })
+        } else {
+            this.replace(this.source())
+        }
+    }
+
+    render(): void {
+        trackLightBindingCreated(this, 'AtomTextBinding')
+        this.run()
     }
     destroy(parentHandle?: boolean, parentHandleComputed?: boolean) {
         trackHostDestroyed(this)
-        if (this.effect) trackLightBindingDestroyed(this.effect)
+        trackLightBindingDestroyed(this)
         if (!parentHandleComputed) {
-            this.effect?.destroy()
+            // CAUTION 用静态 destroy 而不是 super.destroy()：Host.destroy 的第一个参数
+            //  （parentHandle）与 ReactiveEffect.destroy 的 ignoreChildren 语义不同，不能透传
+            ReactiveEffect.destroy(this)
         }
         if (!parentHandle) {
             this.element.remove()

--- a/src/ComponentHost.ts
+++ b/src/ComponentHost.ts
@@ -13,7 +13,20 @@ import {
 } from "./DOM";
 import {Host, PathContext} from "./Host";
 import {createHost} from "./createHost";
-import {Component, ComponentNode, EffectHandle, Props, RenderContext} from "./types";
+import {
+    Component,
+    ComponentNode,
+    CreateElementFn,
+    CreateSVGElementFn,
+    EffectHandle,
+    ExposeFn,
+    OnCleanupFn,
+    Props,
+    RenderContext,
+    ReuseFn,
+    UseEffectFn,
+    UseLayoutEffectFn,
+} from "./types";
 import {assert} from "./util";
 import {Portal} from "./Portal.js";
 import {createRef, createRxRef} from "./ref.js";
@@ -68,6 +81,15 @@ interface PropsWithConfig {
 }
 
 const INNER_CONFIG_PROP = '__config__'
+
+// 无 AOP 配置的组件共享同一个空 itemConfig，避免每个组件实例保留一个空对象
+const EMPTY_ITEM_CONFIG: Record<string, ConfigItem> = {}
+const EMPTY_COMPONENT_PROP: Props = {}
+
+// createPortal 不依赖组件实例，所有组件共享同一个函数
+function createPortalShared(content: JSX.Element|ComponentNode|Function, container: HTMLElement) {
+    return createElement(Portal, {container, content})
+}
 /**
  * @internal
  */
@@ -75,23 +97,35 @@ export class ComponentHost implements Host{
     static typeIds = new Map<Function, number>()
     type: Component
     public innerHost?: Host
-    innerReusedHosts: ReusableHost[] = []
-    props: Props
-    public layoutEffects = new Set<EffectHandle>()
-    public effects = new Set<EffectHandle>()
-    public destroyCallback = new Set<Exclude<ReturnType<EffectHandle>, void>>()
-    public layoutEffectDestroyHandles = new Set<Exclude<ReturnType<EffectHandle>, void>>()
-    public refs: {[k:string]: any} = {}
-    public itemConfig : {[k:string]:ConfigItem} = {}
+    // CAUTION 以下所有容器/闭包字段全部惰性分配：一个典型的小组件（不用
+    //  effect/ref/expose/context/reusable）不应该为这些"可能用到的能力"付常驻内存。
+    innerReusedHosts?: ReusableHost[]
+    props!: Props
+    public layoutEffects?: Set<EffectHandle>
+    public effects?: Set<EffectHandle>
+    public destroyCallback?: Set<Exclude<ReturnType<EffectHandle>, void>>
+    public layoutEffectDestroyHandles?: Set<Exclude<ReturnType<EffectHandle>, void>>
+    _refs?: {[k:string]: any}
+    public itemConfig!: {[k:string]:ConfigItem}
     public children: any
-    public frame?: ManualCleanup[] = []
+    public frame?: ManualCleanup[]
     public name: string
-    public exposed: {[k:string]:any} = {}
+    _exposed?: {[k:string]:any}
     public renderContext?: RenderContext
+    // context.set 的存储，只有真正用到 context 的组件才会分配（见 ensureDataContext）
+    dataContext?: DataContext
     public refProp?: RefObject|RefFn
     public thisProp?: RefObject|RefFn
     public inputProps: Props
     deleteLayoutEffectCallback?: () => void
+    // 惰性缓存的 renderContext 闭包（只有组件解构对应能力时才分配）
+    _createElement?: CreateElementFn
+    _createSVGElement?: CreateSVGElementFn
+    _useLayoutEffect?: UseLayoutEffectFn
+    _useEffect?: UseEffectFn
+    _onCleanup?: OnCleanupFn
+    _expose?: ExposeFn
+    _reusable?: ReuseFn
     constructor({ type, props: inputProps = {}, children }: ComponentNode, public placeholder: UnhandledPlaceholder, public pathContext: PathContext) {
         if (!ComponentHost.typeIds.has(type)) {
             ComponentHost.typeIds.set(type, ComponentHost.typeIds.size)
@@ -99,11 +133,19 @@ export class ComponentHost implements Host{
 
         this.name = type.name
         this.type = type
-        this.props = {}
         this.refProp = inputProps.ref
         this.thisProp = inputProps.__this
         this.inputProps = inputProps
         this.children = children
+    }
+    get refs(): {[k:string]: any} {
+        return this._refs ??= {}
+    }
+    get exposed(): {[k:string]: any} {
+        return this._exposed ??= {}
+    }
+    ensureDataContext(): DataContext {
+        return this.dataContext ??= new DataContext(this.pathContext.hostPath)
     }
 
     parseItemConfigFromProp(itemConfig: any, key:string, value:any, props: Props) {
@@ -217,7 +259,7 @@ export class ComponentHost implements Host{
         }
         return this.cachedContextComponentProps
     }
-    createHTMLOrSVGElement = (isSVG: boolean, type: JSXElementType, rawProps : AttributesArg, ...children: any[]) : ReturnType<typeof createElement> => {
+    createHTMLOrSVGElement(isSVG: boolean, type: JSXElementType, rawProps : AttributesArg, ...children: any[]) : ReturnType<typeof createElement> {
         const isComponent = typeof type === 'function'
 
         const name = rawProps ? rawProps['as'] : undefined
@@ -315,26 +357,41 @@ export class ComponentHost implements Host{
 
         return node
     }
-    createElement = this.createHTMLOrSVGElement.bind(this, false)
-    createSVGElement = this.createHTMLOrSVGElement.bind(this, true)
-    createPortal = (content: JSX.Element|ComponentNode|Function, container: HTMLElement) => {
-        return createElement(Portal, {container, content})
+    // CAUTION 下面这些都是惰性分配的 renderContext 能力闭包：只在组件真正解构/使用时创建
+    get createElement(): CreateElementFn {
+        return this._createElement ??= this.createHTMLOrSVGElement.bind(this, false)
     }
-    reusable = (reusableNode: any) => {
-        const reusedHost = new ReusableHost(reusableNode, new Comment('reusable'), this.pathContext)
-        this.innerReusedHosts.push(reusedHost)
-        return reusedHost
+    get createSVGElement(): CreateSVGElementFn {
+        return this._createSVGElement ??= this.createHTMLOrSVGElement.bind(this, true) as CreateSVGElementFn
+    }
+    get createPortal() {
+        return createPortalShared
+    }
+    get reusable(): ReuseFn {
+        return this._reusable ??= (reusableNode: any) => {
+            const reusedHost = new ReusableHost(reusableNode, new Comment('reusable'), this.pathContext)
+            ;(this.innerReusedHosts ??= []).push(reusedHost)
+            return reusedHost
+        }
     }
     // 处理视图相关的 effect
-    useLayoutEffect = (callback: EffectHandle) => {
-        this.layoutEffects.add(callback)
+    get useLayoutEffect(): UseLayoutEffectFn {
+        return this._useLayoutEffect ??= (callback: EffectHandle) => {
+            (this.layoutEffects ??= new Set()).add(callback)
+        }
     }
     // 处理纯业务相关的 effect，例如建立长连接等
-    useEffect = (callback: EffectHandle) => {
-        this.effects.add(callback)
+    get useEffect(): UseEffectFn {
+        return this._useEffect ??= (callback: EffectHandle) => {
+            (this.effects ??= new Set()).add(callback)
+        }
     }
-    createRef = createRef
-    createRxRef = createRxRef
+    get createRef() {
+        return createRef
+    }
+    get createRxRef() {
+        return createRxRef
+    }
     normalizePropsByPropTypes(propTypes: NonNullable<Component["propTypes"]>, props: Props) {
         const finalProps: Props = {...props}
         // TODO dev 模式下类型检查
@@ -362,7 +419,7 @@ export class ComponentHost implements Host{
     }
     attachRef(ref: RefObject|RefFn) {
         const refValue = {
-            ...this.exposed,
+            ...this._exposed,
             refs: this.refs
         }
 
@@ -387,19 +444,23 @@ export class ComponentHost implements Host{
           ref.current = null
        }
     }
-    expose = (value:any, name?: string) => {
-        if (typeof value === 'object' && name === undefined) {
-            // kv 形式的 expose
-            Object.assign(this.exposed, value)
-        } else if( typeof name === 'string'){
-            // 单个 expose
-            this.exposed[name] = value
-        }
+    get expose(): ExposeFn {
+        return this._expose ??= ((value:any, name?: string) => {
+            if (typeof value === 'object' && name === undefined) {
+                // kv 形式的 expose
+                Object.assign(this.exposed, value)
+            } else if( typeof name === 'string'){
+                // 单个 expose
+                this.exposed[name] = value
+            }
 
-        return value
+            return value
+        }) as ExposeFn
     }
-    onCleanup = (callback: () => any) => {
-        this.destroyCallback.add(callback)
+    get onCleanup(): OnCleanupFn {
+        return this._onCleanup ??= (callback: () => any) => {
+            (this.destroyCallback ??= new Set()).add(callback)
+        }
     }
     evaluateBoundProps(inputProps:Props, renderContext:RenderContext) {
         return (this.type.boundProps || []).map(b => {
@@ -433,7 +494,26 @@ export class ComponentHost implements Host{
 
         return last
     }
+    // 判断 props 中是否有 $ 前缀的 AOP 配置 key
+    static hasConfigProps(props: Props) {
+        for (const key in props) {
+            if (key.charCodeAt(0) === 36) return true // '$'
+        }
+        return false
+    }
     getFinalPropsAndItemConfig(): PropsWithConfig {
+        // 快速路径：没有 boundProps/postBoundProps/透传 config/$ 前缀 key 的普通组件（绝大多数），
+        //  不需要 evaluate/concat/reduce 的整套合并流程，itemConfig 直接共享空对象。
+        const type = this.type
+        if (!type.boundProps && !type.postBoundProps &&
+            !this.inputProps[INNER_CONFIG_PROP] &&
+            !ComponentHost.hasConfigProps(this.inputProps)) {
+            const props = type.propTypes ?
+                this.normalizePropsByPropTypes(type.propTypes, this.inputProps) :
+                {...this.inputProps}
+            return { props, itemConfig: EMPTY_ITEM_CONFIG, componentProp: EMPTY_COMPONENT_PROP }
+        }
+
         const inputPropsWithDefaultValue = this.type.propTypes ? this.normalizePropsByPropTypes(this.type.propTypes, this.inputProps) : this.inputProps
         const evaluatedBoundProps = this.evaluateBoundProps(inputPropsWithDefaultValue, this.renderContext!)
 
@@ -455,23 +535,9 @@ export class ComponentHost implements Host{
             assert(false, 'should never rerender')
         }
 
-        // CAUTION 注意这里 children 的写法，没有children 就不要传，免得后面 props 继续往下透传的时候出问题。
-        this.renderContext = {
-            Fragment,
-            createElement: this.createElement,
-            createSVGElement: this.createSVGElement,
-            refs: this.refs,
-            useLayoutEffect: this.useLayoutEffect,
-            useEffect: this.useEffect,
-            pathContext: this.pathContext,
-            context: new DataContext(this.pathContext.hostPath),
-            createPortal: this.createPortal,
-            createRef: this.createRef,
-            createRxRef: this.createRxRef,
-            onCleanup: this.onCleanup,
-            expose: this.expose,
-            reusable: this.reusable,
-        }
+        // CAUTION renderContext 是一个全 getter 的轻量包装：组件只为它真正解构的能力付费
+        //  （闭包/refs 对象/DataContext 都在第一次访问时才分配）。
+        this.renderContext = new ComponentRenderContext(this)
 
         withReactiveTrace({
             type: 'component-render',
@@ -500,7 +566,9 @@ export class ComponentHost implements Host{
             } finally {
                 // CAUTION 无论组件是否抛错，都必须弹出 collect frame，
                 //  否则 collect frame 栈会错位，后续渲染收集的 effect 会泄漏到错误的 frame 里。
-                this.frame = getFrame()
+                //  空 frame 不保留（多数组件 render 中不创建 computed），省一个常驻数组。
+                const frame = getFrame()
+                if (frame.length) this.frame = frame
             }
             // CAUTION collect effects end
             // 就用当前 component 的 placeholder
@@ -515,30 +583,33 @@ export class ComponentHost implements Host{
             this.attachThis(this.thisProp)
         }
 
-        this.effects.forEach(effect => {
+        this.effects?.forEach(effect => {
             const handle = effect()
             // 也支持 async function return promise，只不过不做处理
-            if (typeof handle === 'function') this.destroyCallback.add(handle)
+            if (typeof handle === 'function') (this.destroyCallback ??= new Set()).add(handle)
         })
 
-        // 已经 root attach 了，动态生成的节点，需要手动触发 layoutEffect。因为没有 attach 事件了。
-        if (this.pathContext.root.attached) {
-            this.runLayoutEffect()
-        } else {
-            // CAUTION 一定要保存退订函数，组件如果在 root attach 之前被销毁，
-            //  必须退订，否则 attach 时会对已销毁的组件执行 layoutEffect/ref。
-            this.deleteLayoutEffectCallback = this.pathContext.root.on('attach', this.runLayoutEffect, {once: true})
+        // 没有 layoutEffect 也没有 ref 的组件（绝大多数）完全不需要参与 attach 流程
+        if (this.layoutEffects || this.refProp) {
+            // 已经 root attach 了，动态生成的节点，需要手动触发 layoutEffect。因为没有 attach 事件了。
+            if (this.pathContext.root.attached) {
+                this.runLayoutEffect()
+            } else {
+                // CAUTION 一定要保存退订函数，组件如果在 root attach 之前被销毁，
+                //  必须退订，否则 attach 时会对已销毁的组件执行 layoutEffect/ref。
+                this.deleteLayoutEffectCallback = this.pathContext.root.on('attach', () => this.runLayoutEffect(), {once: true})
+            }
         }
     }
-    runLayoutEffect = () => {
+    runLayoutEffect() {
         // CAUTION 一定是渲染之后才调用 ref，这样才能获得 dom 信息。
         if (this.refProp) {
             this.attachRef(this.refProp)
         }
 
-        this.layoutEffects.forEach(layoutEffect => {
+        this.layoutEffects?.forEach(layoutEffect => {
             const handle = layoutEffect()
-            if (typeof handle === 'function') this.layoutEffectDestroyHandles.add(handle)
+            if (typeof handle === 'function') (this.layoutEffectDestroyHandles ??= new Set()).add(handle)
         })
     }
     destroy(parentHandle?: boolean, parentHandleComputed?: boolean) {
@@ -556,10 +627,10 @@ export class ComponentHost implements Host{
         // CAUTION 注意这里， ComponentHost 自己是不处理 dom 的。
         // innerHost 可能不存在（render 抛错被中断的场景）
         this.innerHost?.destroy(parentHandle, parentHandleComputed)
-        this.layoutEffectDestroyHandles.forEach(handle => handle())
-        this.destroyCallback.forEach(callback => callback())
+        this.layoutEffectDestroyHandles?.forEach(handle => handle())
+        this.destroyCallback?.forEach(callback => callback())
 
-        this.innerReusedHosts.forEach(host => host.destroyReusable())
+        this.innerReusedHosts?.forEach(host => host.destroyReusable())
 
         // 删除 dom
         // CAUTION placeholder 与 innerHost 共享，innerHost 自己会负责移除
@@ -597,32 +668,83 @@ type ConfigItem = {
 }
 
 export class DataContext{
-    public valueByType: Map<any, any>
+    // CAUTION 惰性创建：只有真正 set 过 context 的组件（Provider）才分配 Map
+    _valueByType?: Map<any, any>
     constructor(public hostPath: LinkedNode<Host>) {
-        this.valueByType = new Map<any, any>()
+    }
+    get valueByType(): Map<any, any> {
+        return this._valueByType ??= new Map<any, any>()
     }
     get(contextType:any) {
         // 找到最近具有 contextType 的 host
+        // CAUTION 直接读 ComponentHost.dataContext 而不是 renderContext.context：
+        //  后者是惰性 getter，读取会给沿途每个祖先组件分配 DataContext
         let start: LinkedNode<Host>|null = this.hostPath
         while(start) {
             if (start.node instanceof ComponentHost) {
-                if (start.node.renderContext!.context.valueByType.has(contextType)) {
-                    return start.node.renderContext!.context.valueByType.get(contextType)
+                const valueByType = start.node.dataContext?._valueByType
+                if (valueByType?.has(contextType)) {
+                    return valueByType.get(contextType)
                 }
             }
             start = start.prev
         }
-        // for (let i = this.hostPath.length - 1; i >= 0; i--) {
-        //     const host = this.hostPath[i]
-        //     if (host instanceof ComponentHost) {
-        //         if (host.renderContext!.context.valueByType.has(contextType)) {
-        //             return host.renderContext!.context.valueByType.get(contextType)
-        //         }
-        //     }
-        // }
     }
     set(contextType: any, value: any) {
         this.valueByType.set(contextType, value)
+    }
+}
+
+/**
+ * @internal
+ *
+ * 传给组件函数的第二个参数。全部成员都是 getter：组件解构哪个能力，才为哪个能力分配
+ * 闭包/对象。典型的小组件只解构 createElement，整个 context 的常驻成本就是这一个
+ * wrapper 对象 + 一个 bind 闭包。
+ */
+export class ComponentRenderContext implements RenderContext {
+    constructor(public host: ComponentHost) {}
+    get Fragment() {
+        return Fragment
+    }
+    get createElement(): CreateElementFn {
+        return this.host.createElement
+    }
+    get createSVGElement(): CreateSVGElementFn {
+        return this.host.createSVGElement
+    }
+    get refs() {
+        return this.host.refs
+    }
+    get useLayoutEffect(): UseLayoutEffectFn {
+        return this.host.useLayoutEffect
+    }
+    get useEffect(): UseEffectFn {
+        return this.host.useEffect
+    }
+    get pathContext() {
+        return this.host.pathContext
+    }
+    get context(): DataContext {
+        return this.host.ensureDataContext()
+    }
+    get createPortal() {
+        return this.host.createPortal
+    }
+    get createRef() {
+        return createRef
+    }
+    get createRxRef() {
+        return createRxRef
+    }
+    get onCleanup(): OnCleanupFn {
+        return this.host.onCleanup
+    }
+    get expose(): ExposeFn {
+        return this.host.expose
+    }
+    get reusable(): ReuseFn {
+        return this.host.reusable
     }
 }
 

--- a/src/FunctionHost.ts
+++ b/src/FunctionHost.ts
@@ -1,4 +1,4 @@
-import {Notifier} from "data0";
+import {Notifier, ReactiveEffect} from "data0";
 import {Host, PathContext} from "./Host";
 import {createHost} from "./createHost";
 import {insertBefore} from './DOM'
@@ -15,16 +15,22 @@ type FunctionNodeContext = {
 type FunctionNode = (context:FunctionNodeContext) => ChildNode|DocumentFragment|string|number|null|boolean
 /**
  * @internal
+ *
+ * CAUTION FunctionHost 自己就是绑定 effect（继承 DeferredBindingEffect），不再为每个函数
+ *  节点单独分配一个 effect 对象 + update 闭包；同时自己实现 onCleanup，直接把自己作为
+ *  source 的 context 传入，省掉每实例的 context 对象 + 闭包。
+ *  长列表里每行的函数文本绑定都会经过这里，合并后每行少两个对象和两个闭包的常驻内存。
  */
-export class FunctionHost implements Host{
-    effect?: DeferredBindingEffect
+export class FunctionHost extends DeferredBindingEffect implements Host{
     innerHost: Host|null = null
     // 文本快速路径：函数返回原始值时直接复用一个 Text 节点
     textNode: Text|null = null
     cleanups?: (() => any)[]
     sourceContext?: FunctionNodeContext
-    destroyed = false
     constructor(public source: FunctionNode, public placeholder:Comment|Text, public pathContext: PathContext) {
+        super()
+        // Host 的生命周期由宿主树显式管理，不能被创建时的 collect frame/父 effect 接管
+        this.detachFromCreationContext()
     }
     get element() : HTMLElement|Comment|Text|SVGElement{
         return this.textNode || this.innerHost?.element || this.placeholder
@@ -41,19 +47,26 @@ export class FunctionHost implements Host{
         }
     }
     render(): void {
-        const host = this
-        // context 对象整个 host 生命周期只创建一次，避免每次重算都分配
-        this.sourceContext = {
-            onCleanup(cleanup: () => any) {
-                (host.cleanups ||= []).push(cleanup)
+        // CAUTION 绝大多数函数节点是 () => atom() 这类零参函数，不会用到 context，
+        //  只有 source 声明了参数（含解构 ({onCleanup})，length 为 1）才分配 context 对象 + 闭包。
+        //  onCleanup 必须是独立闭包而不是方法引用，用户可能解构后脱离 this 调用。
+        if (this.source.length > 0) {
+            const host = this
+            this.sourceContext = {
+                onCleanup(cleanup: () => any) {
+                    (host.cleanups ||= []).push(cleanup)
+                }
             }
         }
-        this.effect = new DeferredBindingEffect((effect) => this.renderSource(effect as DeferredBindingEffect))
-        trackLightBindingCreated(this.effect, 'FunctionNodeBinding')
-        this.effect.run()
+        trackLightBindingCreated(this, 'FunctionNodeBinding')
+        this.run()
     }
     // 是否已经完成过一次渲染，诊断 trace 用它区分初次 render 和 recompute
     renderedOnce = false
+    // DeferredBindingEffect 触发时的回调（以原型方法提供，替代构造器闭包）
+    update() {
+        this.renderSource(this)
+    }
     renderSource(effect: DeferredBindingEffect) {
         // CAUTION 诊断关闭（生产环境）时不分配 trace frame 对象，函数节点重算是热路径
         if (isAxiiDiagnosticsEnabled()) {
@@ -82,6 +95,7 @@ export class FunctionHost implements Host{
         this.runCleanups()
         let node: ReturnType<FunctionNode>|null = null
         try {
+            // 零参 source 用不到 context，直接传 undefined，省掉每实例的 context 分配
             node = this.source(this.sourceContext!)
         } catch (e) {
             // 函数节点重算抛错：如果外部通过 root.on('error') 注册了处理器，则报告错误并把该区域渲染为空
@@ -126,11 +140,13 @@ export class FunctionHost implements Host{
         this.destroyInnerHost()
         const newPlaceholder = document.createComment('computed node')
         insertBefore(newPlaceholder, this.placeholder)
-        const host = createHost(node, newPlaceholder, {...this.pathContext, hostPath: createLinkedNode<Host>(this, this.pathContext.hostPath)})
-        // 内部 host 的渲染不应该被当前 effect 追踪依赖/收集子 effect，
+        // CAUTION 内部 host 的渲染不应该被当前 effect 追踪依赖/收集子 effect，
         //  否则内层的响应式内容变化会导致整个函数节点重算。
+        //  AtomHost/FunctionHost 这类 host 本身就是 effect，对象创建时就可能被父 effect
+        //  收集，所以 pauseCollectChild 必须在 createHost 之前。
         Notifier.instance.pauseTracking()
         effect.pauseCollectChild()
+        const host = createHost(node, newPlaceholder, {...this.pathContext, hostPath: createLinkedNode<Host>(this, this.pathContext.hostPath)})
         host.render()
         effect.resumeCollectChild()
         Notifier.instance.resetTracking()
@@ -147,10 +163,11 @@ export class FunctionHost implements Host{
     }
     destroy(parentHandle?: boolean, parentHandleComputed?: boolean) {
         trackHostDestroyed(this)
-        if (this.effect) trackLightBindingDestroyed(this.effect)
-        this.destroyed = true
+        trackLightBindingDestroyed(this)
         if (!parentHandleComputed) {
-            this.effect?.destroy()
+            // CAUTION 用静态 destroy 而不是 super.destroy()：Host.destroy 的第一个参数
+            //  （parentHandle）与 ReactiveEffect.destroy 的 ignoreChildren 语义不同，不能透传
+            ReactiveEffect.destroy(this)
         }
         this.runCleanups()
         this.destroyInnerHost(parentHandle)

--- a/src/LightBindingEffect.ts
+++ b/src/LightBindingEffect.ts
@@ -1,11 +1,30 @@
 import {
     isData0RetainedObjectDiagnosticsEnabled,
+    ManualCleanup,
     ReactiveEffect,
     setRetainedReactiveEffectSource,
     trackRetainedReactiveEffectCreated
 } from "data0";
 
 type SkipIndicator = { skip: boolean }
+
+// CAUTION 下面三个共享函数用来覆盖 data0 ReactiveEffect 构造器里逐实例分配的
+//  pauseCollectChild/resumeCollectChild/dispatch 箭头函数字段。
+//  长列表里每个文本/属性绑定都是一个 effect，3 个闭包 × 每实例 ≈ 数百 KB 的常驻内存。
+//  覆盖后实例字段指向共享函数（hidden class 不变），构造器里创建的闭包立即变成垃圾。
+//  这依赖 data0 内部始终以方法调用形式使用它们（effect.dispatch(...) 等），
+//  data0 的 L.destroy/prepareTracking 均满足。
+function sharedPauseCollectChild(this: ReactiveEffect) {
+    this.shouldCollectChild = false
+}
+function sharedResumeCollectChild(this: ReactiveEffect) {
+    this.shouldCollectChild = true
+}
+function sharedDispatch(this: ReactiveEffect, event: string, ...args: any[]) {
+    // 与 data0 实例版 dispatch 行为完全一致（_eventToCallbacks 是惰性创建的私有字段）
+    const callbacks = (this as any)._eventToCallbacks?.get(event)
+    if (callbacks) callbacks.forEach((callback: Function) => callback.call(this, ...args))
+}
 
 /**
  * @internal
@@ -21,13 +40,25 @@ type SkipIndicator = { skip: boolean }
  * - 触发时同步重跑 update 函数（与之前 autorun(fn, true)/computed(fn, undefined, true) 的
  *   immediate 语义一致）；
  * - 没有 applyPatch/async/状态机，构造成本只有基类的字段初始化。
+ *
+ * update 可以通过构造器闭包传入，也可以由子类以原型方法提供（AtomHost/FunctionHost
+ * 把自己和 effect 合并成同一个对象时用后者，省掉一个闭包 + 一个对象）。
  */
 export class LightBindingEffect extends ReactiveEffect {
-    constructor(public update: (effect: LightBindingEffect) => void, public skipIndicator?: SkipIndicator) {
+    // 可选方法声明（而不是属性声明），子类既可以用原型方法覆写，也可以由构造器闭包赋值
+    update?(effect: LightBindingEffect): void
+    skipIndicator?: SkipIndicator
+    constructor(update?: (effect: LightBindingEffect) => void, skipIndicator?: SkipIndicator) {
         // CAUTION 不传 getter：跳过基类构造器里对 getter 的 AsyncFunction/GeneratorFunction
         //  判断（两次 constructor.name 字符串比较，在长列表创建时可测量）。
         //  active 和 retained diagnostics 登记在下面手动补上。
         super()
+        // 用共享函数覆盖基类构造器里逐实例分配的三个闭包字段，降低每绑定的常驻内存
+        this.pauseCollectChild = sharedPauseCollectChild
+        this.resumeCollectChild = sharedResumeCollectChild
+        this.dispatch = sharedDispatch
+        if (update) this.update = update
+        if (skipIndicator) this.skipIndicator = skipIndicator
         this.active = true
         if (isData0RetainedObjectDiagnosticsEnabled()) {
             trackRetainedReactiveEffectCreated(this)
@@ -36,13 +67,41 @@ export class LightBindingEffect extends ReactiveEffect {
         }
     }
     callGetter() {
-        return this.update(this)
+        return this.update!(this)
     }
     run() {
         // 已销毁的 effect 不应再执行副作用（基类对 inactive 的 run 会退化成直接调用 getter）
         if (!this.active) return
         if (this.skipIndicator?.skip) return
         return super.run()
+    }
+    /**
+     * 把（AtomHost/FunctionHost 这类同时也是 Host 的）effect 从创建时的上下文中摘除：
+     * - ManualCleanup collect frame：Host 对象的销毁由宿主树显式管理（destroy(parentHandle,
+     *   parentHandleComputed) 带 DOM 语义），绝不能被组件 frame 的 forEach(x => x.destroy())
+     *   以无参形式误销毁；
+     * - 父 effect 收集：Host 的生命周期与创建它的 effect 无关（列表行由 splice 显式销毁），
+     *   不能挂在父 effect 的 children 里被 destroyChildren 提前 deactivate。
+     */
+    detachFromCreationContext() {
+        const frames = ManualCleanup.collectFrames as unknown as object[][]
+        if (frames.length) {
+            const frame = frames[frames.length - 1]
+            if (frame[frame.length - 1] === this) frame.pop()
+        }
+        const parent = this.parent
+        if (parent) {
+            const children = (parent as any)._children as ReactiveEffect[] | undefined
+            if (children?.length) {
+                const last = children.pop()!
+                if (last !== this) {
+                    children[this.index] = last
+                    last.index = this.index
+                }
+            }
+            this.parent = undefined
+            this.index = 0
+        }
     }
 }
 

--- a/src/LightBindingEffect.ts
+++ b/src/LightBindingEffect.ts
@@ -14,6 +14,8 @@ type SkipIndicator = { skip: boolean }
 //  覆盖后实例字段指向共享函数（hidden class 不变），构造器里创建的闭包立即变成垃圾。
 //  这依赖 data0 内部始终以方法调用形式使用它们（effect.dispatch(...) 等），
 //  data0 的 L.destroy/prepareTracking 均满足。
+//  data0 >= 2.0.1 已把这三个函数改为原型方法（不再逐实例分配闭包），此时无需覆盖，
+//  覆盖反而会新增实例槽位，所以用模块级探测做一次性判断。
 function sharedPauseCollectChild(this: ReactiveEffect) {
     this.shouldCollectChild = false
 }
@@ -25,6 +27,7 @@ function sharedDispatch(this: ReactiveEffect, event: string, ...args: any[]) {
     const callbacks = (this as any)._eventToCallbacks?.get(event)
     if (callbacks) callbacks.forEach((callback: Function) => callback.call(this, ...args))
 }
+const effectHelpersOnPrototype = typeof (ReactiveEffect.prototype as any).pauseCollectChild === 'function'
 
 /**
  * @internal
@@ -54,9 +57,12 @@ export class LightBindingEffect extends ReactiveEffect {
         //  active 和 retained diagnostics 登记在下面手动补上。
         super()
         // 用共享函数覆盖基类构造器里逐实例分配的三个闭包字段，降低每绑定的常驻内存
-        this.pauseCollectChild = sharedPauseCollectChild
-        this.resumeCollectChild = sharedResumeCollectChild
-        this.dispatch = sharedDispatch
+        // （data0 >= 2.0.1 已是原型方法，无需覆盖）
+        if (!effectHelpersOnPrototype) {
+            this.pauseCollectChild = sharedPauseCollectChild
+            this.resumeCollectChild = sharedResumeCollectChild
+            this.dispatch = sharedDispatch
+        }
         if (update) this.update = update
         if (skipIndicator) this.skipIndicator = skipIndicator
         this.active = true

--- a/src/StaticArrayHost.ts
+++ b/src/StaticArrayHost.ts
@@ -10,7 +10,6 @@ import {trackHostDestroyed} from "./retainedObjectDiagnostics.js";
  * @internal
  */
 export class StaticArrayHost implements Host{
-    computed = undefined
 
     childHosts: Host[] = []
     constructor(public source: any[], public placeholder: Comment, public pathContext: PathContext) {

--- a/src/StaticHost.ts
+++ b/src/StaticHost.ts
@@ -429,15 +429,15 @@ export const StaticHostConfig = {
  */
 export class StaticHost implements Host {
     static styleManager = new StyleManager()
+    // CAUTION 下面这些可选字段都不带初始化器：StaticHost/CompactElementHost 是数量最大的
+    //  host（长列表每行一个），不用的能力不占实例槽位（useDefineForClassFields=false 下
+    //  无初始化器的字段不产生构造期赋值）。
     // 如果有 detachStyledChildren，会设为 true
-    public forceHandleElement: boolean = false
-    // CAUTION Component 只因为 props 的引用变化而重新 render。
-    //  只有有 diff 算发以后才会出现引用变化的情况，现在我们还没有实现。所以现在其实永远不会重 render
-    computed = undefined
+    public forceHandleElement?: boolean
     reactiveHosts?: Host[]
     attrEffects?: LightBindingEffect[]
     // 是否有 style 类型的响应式属性，只有这种情况才需要 StyleManager 的 mount/unmount 记账
-    usesStyleManager = false
+    usesStyleManager?: boolean
     refHandles?: RefHandleInfo[]
     detachStyledChildren?: DetachStyledInfo[]
     removeAttachListener?: () => void
@@ -479,7 +479,7 @@ export class StaticHost implements Host {
             } else {
                 // CAUTION 一定要保存退订函数，元素如果在 root attach 之前被销毁，
                 //  必须退订，否则 attach 时会把已销毁的元素重新附加到 ref 上。
-                this.removeAttachListener = this.pathContext.root.on('attach', this.attachRefs, {once: true})
+                this.removeAttachListener = this.pathContext.root.on('attach', () => this.attachRefs(), {once: true})
             }
         }
         // mount/unmount 记账只服务于 StyleManager 的 stylesheet 引用计数，
@@ -582,7 +582,9 @@ export class StaticHost implements Host {
         const testId = generateGlobalElementStaticId(this.pathContext.hostPath, elementPath)
         setAttribute(el, 'data-testid', testId)
     }
-    attachRefs = () => {
+    // CAUTION 原型方法而不是实例箭头函数：每个元素 host 都有这个字段的话，长列表每行多一个闭包。
+    //  需要脱离 this 使用的注册点（root.on('attach')）自己包一层箭头函数，只有带 ref 的元素才分配。
+    attachRefs() {
         this.refHandles?.forEach(({ handle, el }: RefHandleInfo) => {
             createElement.attachRef(el, handle)
         })
@@ -746,7 +748,7 @@ export class CompactElementHost extends StaticHost {
             if (this.pathContext.root.attached) {
                 this.attachRefs()
             } else {
-                this.removeAttachListener = this.pathContext.root.on('attach', this.attachRefs, {once: true})
+                this.removeAttachListener = this.pathContext.root.on('attach', () => this.attachRefs(), {once: true})
             }
         }
         if (this.usesStyleManager) {

--- a/src/retainedObjectDiagnostics.ts
+++ b/src/retainedObjectDiagnostics.ts
@@ -34,8 +34,12 @@ let activeCompactHosts = 0
 
 // 已经计数过的对象，防止重复 destroy 导致计数为负。
 // value 是创建时登记的类型名，destroy 时直接取用，调用方无需再提供。
-let seenObjects = new WeakMap<object, string>()
-let destroyedObjects = new WeakSet<object>()
+// CAUTION host 与 light binding 分开登记：AtomHost/FunctionHost 把 Host 和绑定 effect
+//  合并成同一个对象后，同一个对象需要同时计入 hosts 和 lightBindings 两套计数。
+let seenHosts = new WeakMap<object, string>()
+let destroyedHosts = new WeakSet<object>()
+let seenBindings = new WeakMap<object, string>()
+let destroyedBindings = new WeakSet<object>()
 
 function increase(map: CountMap, key: string, delta = 1) {
     const next = (map[key] ?? 0) + delta
@@ -54,8 +58,10 @@ function resetCounts() {
     }
     activeStyleHostStates = 0
     activeCompactHosts = 0
-    seenObjects = new WeakMap()
-    destroyedObjects = new WeakSet()
+    seenHosts = new WeakMap()
+    destroyedHosts = new WeakSet()
+    seenBindings = new WeakMap()
+    destroyedBindings = new WeakSet()
 }
 
 export function isAxiiRetainedObjectDiagnosticsEnabled() {
@@ -81,8 +87,8 @@ export function resetAxiiRetainedObjectDiagnostics() {
  * @internal
  */
 export function trackHostCreated(host: object, type: string) {
-    if (!enabled || seenObjects.has(host)) return
-    seenObjects.set(host, type)
+    if (!enabled || seenHosts.has(host)) return
+    seenHosts.set(host, type)
     increase(hostCounts.createdByType, type)
     increase(hostCounts.activeByType, type)
 }
@@ -91,10 +97,10 @@ export function trackHostCreated(host: object, type: string) {
  * @internal
  */
 export function trackHostDestroyed(host: object) {
-    if (!enabled || destroyedObjects.has(host)) return
-    const type = seenObjects.get(host)
+    if (!enabled || destroyedHosts.has(host)) return
+    const type = seenHosts.get(host)
     if (type === undefined) return
-    destroyedObjects.add(host)
+    destroyedHosts.add(host)
     increase(hostCounts.destroyedByType, type)
     increase(hostCounts.activeByType, type, -1)
 }
@@ -103,8 +109,8 @@ export function trackHostDestroyed(host: object) {
  * @internal
  */
 export function trackLightBindingCreated(binding: object, type: string) {
-    if (!enabled || seenObjects.has(binding)) return
-    seenObjects.set(binding, type)
+    if (!enabled || seenBindings.has(binding)) return
+    seenBindings.set(binding, type)
     increase(lightBindingCounts.createdByType, type)
     increase(lightBindingCounts.activeByType, type)
 }
@@ -113,10 +119,10 @@ export function trackLightBindingCreated(binding: object, type: string) {
  * @internal
  */
 export function trackLightBindingDestroyed(binding: object) {
-    if (!enabled || destroyedObjects.has(binding)) return
-    const type = seenObjects.get(binding)
+    if (!enabled || destroyedBindings.has(binding)) return
+    const type = seenBindings.get(binding)
     if (type === undefined) return
-    destroyedObjects.add(binding)
+    destroyedBindings.add(binding)
     increase(lightBindingCounts.destroyedByType, type)
     increase(lightBindingCounts.activeByType, type, -1)
 }
@@ -135,7 +141,7 @@ export function trackCompactHostCreated(host: object) {
 export function trackCompactHostDestroyed(host: object) {
     if (!enabled) return
     // 只有 create 阶段被登记过的对象才计数，避免 enable 之前创建的 host 把计数减成负数
-    if (!seenObjects.has(host) || destroyedObjects.has(host)) return
+    if (!seenHosts.has(host) || destroyedHosts.has(host)) return
     activeCompactHosts--
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Follows up on the memory analysis in the benchmark repo (axiijs/benchmark#3): axii's memory weak points were the per-reactive-binding object count and `ComponentHost`'s unconditional pre-allocation. This PR removes retained allocations without touching any hot-path algorithm, so speed is unchanged or slightly better (fewer allocations).

## Changes

**`LightBindingEffect`**
- data0's `ReactiveEffect` constructor (up to 2.0.0) allocates 3 per-instance arrow-function closures (`pauseCollectChild`/`resumeCollectChild`/`dispatch`). Every text/attr/function binding is one such effect, so long lists retained 3 closures per row. They are now overwritten with shared functions right after `super()` — guarded by a module-level probe so the override is skipped when data0 (>= 2.0.1, see companion data0 patch) already provides them as prototype methods.
- `update` can now be provided as a prototype method by subclasses instead of a constructor closure.
- New `detachFromCreationContext()` for host+effect merged classes: removes the object from the ManualCleanup collect frame and from parent-effect adoption, since Host lifecycles are managed explicitly by the host tree.

**`AtomHost` / `FunctionHost`**
- Both now *are* their binding effect (extend `LightBindingEffect`/`DeferredBindingEffect`) instead of holding a separate effect object + update closure: one object and one closure less per binding.
- `FunctionHost` only allocates `sourceContext` (object + closure) when the source function declares a parameter (`source.length > 0`); the ubiquitous `() => atom()` bindings pay nothing.
- `pauseCollectChild` moved before `createHost` in `renderSourceWithoutTrace` since inner hosts are now effects themselves and must not be adopted as children.

**`StaticHost`**
- `attachRefs` is a prototype method (was a per-instance arrow closure — one per list row); the `root.on('attach')` registration wraps it in a closure only for elements that actually have refs.
- Dropped always-emitted field initializers (`forceHandleElement`/`computed`/`usesStyleManager`); unused capabilities no longer occupy instance slots.

**`ComponentHost`**
- All capability state is lazily allocated: the 4 Sets (`layoutEffects`/`effects`/`destroyCallback`/`layoutEffectDestroyHandles`), `refs`/`exposed`/`frame`/`innerReusedHosts`, and every renderContext closure.
- `renderContext` is now a getter-based `ComponentRenderContext` wrapper — a component pays only for the capabilities it destructures (typically just `createElement`, one bind closure).
- `DataContext` map is lazy and context lookup walks `host.dataContext` directly so reads don't allocate contexts on ancestors.
- Components without layoutEffect/ref skip the attach-listener registration entirely.
- Fast path in `getFinalPropsAndItemConfig` for components without `boundProps`/`postBoundProps`/`$`-config keys: skips the evaluate/concat/reduce merge pipeline and shares an empty `itemConfig`.

**`retainedObjectDiagnostics`**
- Hosts and light bindings are tracked in separate WeakMaps so merged host+effect objects are counted in both categories (diagnostic table output is unchanged).

## Measured results (Chromium, GC-forced retained heap, medians)

| Scenario | Before | After (this PR) | + data0 patch | React | Vue | Solid (equiv.) |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| Fine-grained list row (label atom + function child) | 973B | **678B** | **652B** | 306B* | 537B | 490B |
| Atom-child row | 855B | **615B** | **590B** | — | — | — |
| Static row | 253B | **189B** | 189B | 306B | 537B | 108B |
| Component with 1 local state | 2355B | **1013B** | **~990B** | 826B | 1907B | 290B |
| Empty app mount | 124KB | **118KB** | **108KB** | 97KB | 101KB | 52KB |

\* React rows carry no per-row reactivity (full re-render model).

The companion data0 optimization (ReactiveEffect prototype methods, Computed lazy collections, shared primitive-atom prototype) could not be pushed to `sskyy/data0` (no write access for the bot); the full patch is included in the benchmark repo PR as `patches/data0-memory-optimization.patch`.

Leak checks unchanged: clear/destroy returns retained diagnostics to zero at all sizes; 30x create/clear cycles grow ~16KB total (same as Solid).

## Speed (benchmark:real, 4-framework suite)

Summary total improved from 23.7ms baseline to 20.8ms with this PR, and to **18.8ms** with the data0 patch on top — within 1% of Solid (18.6ms; vue 22.3ms, react 67.2ms). Per-test: create-1000 3.65→2.95→2.46ms, update-100 0.28→0.24→0.23ms; no test regressed beyond run-to-run noise.

## Testing

- `npx vitest run`: 398 passed (browser mode), both against npm data0 2.0.0 and the patched local data0 source
- `npx vitest run --config vitest.node.config.ts`: 6 passed
- data0 patch: all 174 data0 tests pass
- `npm run build` clean; benchmark repo re-run end to end against the rebuilt dist.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0c21e9e4-43f2-4834-9c21-5ceda34890a2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0c21e9e4-43f2-4834-9c21-5ceda34890a2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

