### PR TITLE
chore(release): v4.1.0 based on data0 ^2.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "axii",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "description": "A high-performance incremental-update frontend framework without Virtual DOM.",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "axii",
-  "version": "3.9.2",
+  "version": "4.0.0",
   "description": "A high-performance incremental-update frontend framework without Virtual DOM.",
   "repository": {
     "type": "git",
@@ -52,7 +52,7 @@
     "@types/node": "^22.9.3",
     "@vitest/browser": "^3.2.4",
     "@vitest/coverage-v8": "^3.2.4",
-    "data0": "^2.0.0",
+    "data0": "^2.1.0",
     "release-it": "^19.0.4",
     "typescript": "5.9.2",
     "vite": "^7.1.1",
@@ -61,7 +61,7 @@
     "vitest": "^3.2.4"
   },
   "peerDependencies": {
-    "data0": "^2.0.0"
+    "data0": "^2.1.0"
   },
   "release-it": {
     "plugins": {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Releases `axii` **4.1.0**, wired to the newly published `data0@2.1.0`.

## Changes
- Version bumped `3.9.2` → `4.1.0`.
- `data0` dependency bumped to `^2.1.0` (both `devDependencies` and `peerDependencies`), since axii's memory-optimization work relies on the prototype-method / lazy-allocation shape introduced in `data0@2.1.0`.

## Release
- ✅ Published to npm: `axii@4.1.0` (`npm view axii version` → `4.1.0`, `latest`).
- ✅ Registry confirms `peerDependencies: { data0: ^2.1.0 }`.
- Git tag `v4.1.0` pushed.

## Testing
- ✅ `npx vitest run` — full browser suite passes against `data0@2.1.0`.
- ✅ `npm run build` — emits `dist/` (bundle + `.d.ts`).

## Note
`4.0.0` was targeted originally but is already published on npm (2026-05-25) and cannot be overwritten (past the 72h unpublish window), so this release uses `4.1.0` per maintainer instruction.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5bcfda10-a2cc-4e94-994a-83c80fd5a318"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5bcfda10-a2cc-4e94-994a-83c80fd5a318"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

