### PR TITLE
Upgrade data0 to ^2.2.0, adapt to sync error propagation, pin new contract clause

### DIFF
--- a/__tests__/data0Contract.spec.tsx
+++ b/__tests__/data0Contract.spec.tsx
@@ -208,4 +208,32 @@ describe('data0 -> axii trigger info contract', () => {
 
         sub.destroy()
     })
+
+    test('7. sync patch errors propagate synchronously to the mutation site and tracking state survives', () => {
+        // data0 >= 2.2：同步 computed 的 patch/getter 在同步路径上执行，未被消费的错误
+        //  同步抛回到变更调用点（旧版本是 async fullRecompute/patchRecompute，只能变成
+        //  unhandled rejection）。RxListHost 的「未注册 error 钩子时 report + throw 保持
+        //  可观测」出口依赖这一点（errorHandling.spec 的 AxiiError trace 用例）。
+        const list = new RxList(['a'])
+        const c = computed(
+            function computation(this: Computed) {
+                this.manualTrack(list, TrackOpTypes.METHOD, TriggerOpTypes.METHOD)
+                return null
+            },
+            function applyPatch() {
+                throw new Error('patch failed')
+            }
+        )
+        expect(() => list.push('b')).toThrow('patch failed')
+
+        // 抛错后全局追踪状态必须完好：后续 reactive 依赖照常工作
+        const other = new RxList([1])
+        const doubled = other.map(x => x * 2)
+        other.push(2)
+        expect(doubled.data).toEqual([2, 4])
+
+        destroyComputed(c)
+        doubled.destroy()
+        other.destroy()
+    })
 })

--- a/__tests__/errorHandling.spec.tsx
+++ b/__tests__/errorHandling.spec.tsx
@@ -539,14 +539,6 @@ describe('error handling examples', () => {
 
     test('adds RxList patch information to AxiiError reactive traces', async () => {
         const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
-        let rejectedError: unknown
-        const unhandledRejection = new Promise<void>(resolve => {
-            window.addEventListener('unhandledrejection', (event) => {
-                event.preventDefault()
-                rejectedError = event.reason
-                resolve()
-            }, {once: true})
-        })
         // CAUTION 单元素行会走 CompactElementHost（没有独立的行占位符，也没有可破坏的区间），
         //  这里用 Fragment 行保持「元素 ... 行占位符」的真实 DOM 区间，才能构造边界破坏场景。
         const list = new RxList([
@@ -560,12 +552,18 @@ describe('error handling examples', () => {
         )!
         rootEl.insertBefore(firstItemPlaceholder, rootEl.firstChild)
 
-        list.splice(0, 1)
-        await unhandledRejection
+        // CAUTION data0 >= 2.2 的同步 computed patch 是同步执行的：未被 error 钩子消费的
+        //  patch 错误会同步抛回到变更调用点（旧版本只能变成 unhandled rejection）。
+        let thrown: unknown
+        try {
+            list.splice(0, 1)
+        } catch (error) {
+            thrown = error
+        }
 
         const error = consoleError.mock.calls[0][0]
         expect(error).toBeInstanceOf(AxiiError)
-        expect(rejectedError).toBe(error)
+        expect(thrown).toBe(error)
         const axiiError = error as AxiiError
         expect(axiiError.reactiveTrace.some(frame =>
             frame.type === 'rx-list-patch' &&

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "@types/node": "^22.9.3",
     "@vitest/browser": "^3.2.4",
     "@vitest/coverage-v8": "^3.2.4",
-    "data0": "^2.1.0",
+    "data0": "^2.2.0",
     "release-it": "^19.0.4",
     "typescript": "5.9.2",
     "vite": "^7.1.1",
@@ -61,7 +61,7 @@
     "vitest": "^3.2.4"
   },
   "peerDependencies": {
-    "data0": "^2.1.0"
+    "data0": "^2.2.0"
   },
   "release-it": {
     "plugins": {

--- a/src/RxListHost.ts
+++ b/src/RxListHost.ts
@@ -111,12 +111,13 @@ export class RxListHost implements Host{
                         }
                         insertBefore(host.renderNewHosts(hosts), host.placeholder)
                     } catch (error) {
-                        // CAUTION 初始行渲染也发生在 data0 computed 的 computation 里（fullRecompute
-                        //  是 async 函数），向上抛只会变成 unhandled rejection：root error 钩子拿不到
-                        //  错误，该区域永远卡死，后续销毁还会对未初始化的 computed/hosts 再抛错。
-                        //  与 applyPatch 的错误出口对齐：已创建的行全部回收（DOM 还在脱离文档的
-                        //  fragment 里，直接丢弃），区域渲染为空；错误交给 root error 钩子，
-                        //  未消费时先 reportAxiiError 输出结构化报告再继续抛出保持可观测。
+                        // CAUTION 初始行渲染发生在 data0 computed 的 computation 里。data0 >= 2.2
+                        //  同步 computed 全程同步执行，向上抛会同步抛回变更/创建调用点；但错误
+                        //  边界仍在这里：不回收的话该区域卡死，后续销毁还会对未初始化的
+                        //  computed/hosts 再抛错。与 applyPatch 的错误出口对齐：已创建的行全部
+                        //  回收（DOM 还在脱离文档的 fragment 里，直接丢弃），区域渲染为空；
+                        //  错误交给 root error 钩子，未消费时先 reportAxiiError 输出结构化报告
+                        //  再继续抛出保持可观测。
                         for (const created of hosts) created.destroy(true)
                         hosts.length = 0
                         if (!host.pathContext.root.dispatch('error', error)) {
@@ -140,10 +141,11 @@ export class RxListHost implements Host{
                 try {
                     let patchFailed = false
                     for (const info of triggerInfos) {
-                        // CAUTION patch 在 data0 的 computed 里执行，向上抛只会变成 unhandled rejection。
-                        //  外部通过 root.on('error') 注册了处理器时交给处理器（应用保持存活，
-                        //  该列表区域可能处于不一致状态）；否则先 reportAxiiError 输出结构化报告，
-                        //  再继续抛出保持可观测。
+                        // CAUTION patch 在 data0 的 computed 里执行。data0 >= 2.2 同步 patch 是
+                        //  同步执行的：向上抛会同步抛回到变更调用点（list.push 等）。外部通过
+                        //  root.on('error') 注册了处理器时交给处理器（应用保持存活，该列表区域
+                        //  可能处于不一致状态）；否则先 reportAxiiError 输出结构化报告，
+                        //  再继续抛出保持可观测（data0Contract.spec 条款 7 锁定同步抛出行为）。
                         try {
                             if (isAxiiDiagnosticsEnabled()) {
                                 const {method, argv, key, methodResult, type} = info


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Upgrades data0 to the freshly published `^2.2.0` (dev + peer dependency) and adapts axii to its one observable behavior change. Running axii's full suite against the fixed data0 surfaced exactly one behavior change to adapt to, plus one data0-side compat revert (landed in data0 before release, no axii change needed).

## What changed in data0 2.2.0 that affects axii

data0's sync computeds now run fully synchronously: an error thrown from a getter/applyPatch (and not consumed by an error boundary) propagates **synchronously to the mutation site** (`list.splice(...)` call) instead of surfacing as an unhandled rejection from the old `async fullRecompute/patchRecompute`. RxListHost's error-boundary code needed no changes — only a test that explicitly waited for `unhandledrejection` and stale CAUTION comments.

## Changes

- `package.json`: `data0` dev + peer dependency bumped `^2.1.0` → `^2.2.0` (published release).
- `__tests__/errorHandling.spec.tsx`: the AxiiError reactive-trace case now catches the error synchronously from `list.splice()` instead of listening for `unhandledrejection`, and asserts the thrown error is the same reported AxiiError.
- `__tests__/data0Contract.spec.tsx`: new clause 7 pins the new behavior per the repo's contract-testing discipline — sync patch errors throw at the mutation site, and data0's global tracking state survives a throwing patch (subsequent reactive updates keep working).
- `src/RxListHost.ts`: updated the two CAUTION comments that described the old "向上抛只会变成 unhandled rejection" rationale. No code changes.

## data0-side compat fix (context)

The first validation run also failed `fatalBugs13` (F47 sparse-set structured errors): data0's review fixes had converted out-of-bounds `set()` into splice semantics, which broke axii's contract that out-of-contract keys pass through raw for RxListHost to reject with `AXII_LIST_ORDER_BROKEN`. That conversion was reverted in data0 before the 2.2.0 release (with a pass-through contract test on the data0 side), so F47 passes unchanged.

## Testing

- Against the published `data0@2.2.0` package (sibling `../data0/src` temporarily hidden so the npm dist is what's under test): browser suite **45 files, 600 tests passed** (599 existing + 1 new contract test)
- node suite: 6 tests passed; `npm run build` clean; CJS + ESM entry-point smoke tests of the published package pass
- Baseline before the data0 upgrade (data0 v2.1.0): 599/599 passed, confirming zero pre-existing failures and that the only diffs are the two adapted expectations above
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c503d02e-f53f-4f13-b561-bbe83be01ec2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c503d02e-f53f-4f13-b561-bbe83be01ec2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

