### PR TITLE
fix: survive data0 ≥ 2.9 error-recovery computation reruns in RxListHost

### DIFF
--- a/__tests__/data0Contract.spec.tsx
+++ b/__tests__/data0Contract.spec.tsx
@@ -242,15 +242,23 @@ describe('data0 -> axii trigger info contract', () => {
         other.destroy()
     })
 
-    test('8. after a throwing patch the computed resets to dirty; the failed batch is NOT replayed', () => {
-        // 恢复语义：错误后 computed 复位为 dirty，下一次变更正常走 patch；
-        // 失败批次的 triggerInfos 被丢弃、不重放（消费方要么返回 false 走全量，
-        // 要么像 RxListHost 一样 fail-stop 等待上层销毁/恢复）。
+    test('8. after a throwing patch the failed batch is NOT replayed; recovery is version-dependent (2.9+: rerun computation)', () => {
+        // 恢复语义按 data0 版本分两代：
+        // - data0 <= 2.8：错误后 computed 复位 dirty，下一次变更继续走增量 patch。
+        //   CAUTION 抛错批次的 triggerInfos 已丢失——派生数据可能与 source 永久分叉
+        //   （data0 2026-H2 review 的缺陷类 4）。
+        // - data0 >= 2.9（缺陷类 4 修复）：错误后回退到全量重算阶段，下一次变更
+        //   **重跑 computation**（applyPatch 不收 info），保证派生 ≡ 终态 source；
+        //   再下一次恢复增量。消费方必须支持 computation 重跑（RxListHost 的重跑
+        //   语义 = 销毁旧行 + 全量重建，见 data0RecoveryRerun.spec）。
+        // 本测试运行时探测语义代，双代都锁定「失败批次不重放」这一共同条款。
         const list = new RxList(['a', 'b'])
         const received: TriggerInfo[] = []
+        let computationRuns = 0
         let shouldThrow = true
         const c = computed(
             function computation(this: Computed) {
+                computationRuns++
                 this.manualTrack(list, TrackOpTypes.METHOD, TriggerOpTypes.METHOD)
                 return null
             },
@@ -260,6 +268,7 @@ describe('data0 -> axii trigger info contract', () => {
             },
             true
         )
+        expect(computationRuns).toBe(1)
 
         expect(() => list.push('c')).toThrow('patch boom')
         // source 数据已写入（patch 失败不回滚 source）
@@ -268,8 +277,22 @@ describe('data0 -> axii trigger info contract', () => {
         shouldThrow = false
         expect(() => list.push('d')).not.toThrow()
         expect(list.data).toEqual(['a', 'b', 'c', 'd'])
-        expect(received.length).toBe(1)
-        expect(received[0]).toMatchObject({method: 'splice', argv: [3, 0, 'd']})
+
+        const rerunsAfterError = computationRuns > 1
+        if (rerunsAfterError) {
+            // data0 >= 2.9：错误后第一次变更全量重跑，applyPatch 不收 info
+            expect(computationRuns).toBe(2)
+            expect(received.length).toBe(0)
+            // 再下一次变更恢复增量 patch
+            list.push('e')
+            expect(computationRuns).toBe(2)
+            expect(received.length).toBe(1)
+            expect(received[0]).toMatchObject({method: 'splice', argv: [4, 0, 'e']})
+        } else {
+            // data0 <= 2.8：错误后下一次变更仍走增量 patch；失败批次('c')不重放
+            expect(received.length).toBe(1)
+            expect(received[0]).toMatchObject({method: 'splice', argv: [3, 0, 'd']})
+        }
 
         destroyComputed(c)
     })

--- a/__tests__/data0RecoveryRerun.spec.tsx
+++ b/__tests__/data0RecoveryRerun.spec.tsx
@@ -1,0 +1,118 @@
+/**
+ * data0 >= 2.9 错误恢复语义下 RxListHost 的全量重建回归。
+ *
+ * 契约(data0Contract.spec 条款 8):patch 抛错(rethrow 出口)后 data0 把该
+ * computed 回退到全量重算阶段,下一次源变更**重跑 computation**(不是增量 patch)。
+ * 缺陷(2026-H2 复现):RxListHost 的 computation 假定只跑一次,重跑时残留 hosts
+ * 未清理——行组件撞上 "should never rerender" 断言,列表区域永久崩坏。
+ * 修复:computation 开头销毁上一轮 hosts(自摘 DOM)再全量重建。
+ *
+ * 兼容:npm 安装的 data0 2.8 是旧语义(错误后仍走增量 patch,抛错批次丢失),
+ * 运行时探测语义代,旧代下断言 fail-stop 的旧行为(丢失批次不恢复)。
+ */
+import {describe, expect, test} from "vitest";
+import {createElement, createRoot} from "../src/index.js";
+import {computed, Computed, destroyComputed, RxList, TrackOpTypes, TriggerOpTypes} from "data0";
+
+// 运行时探测 data0 的错误恢复语义代(sibling checkout 是 2.9+,npm 安装是 2.8):
+// 2.9+ 在 patch 抛错后回退全量阶段,下一次变更重跑 computation。
+function detectRerunSemantics(): boolean {
+    const list = new RxList([1])
+    let runs = 0
+    let shouldThrow = true
+    const c = computed(
+        function computation(this: Computed) {
+            runs++
+            this.manualTrack(list, TrackOpTypes.METHOD, TriggerOpTypes.METHOD)
+            return null
+        },
+        function applyPatch() {
+            if (shouldThrow) throw new Error('probe boom')
+        },
+        true
+    )
+    try { list.push(2) } catch { /* expected */ }
+    shouldThrow = false
+    list.push(3)
+    const reruns = runs > 1
+    destroyComputed(c)
+    list.destroy()
+    return reruns
+}
+const HAS_RERUN_RECOVERY = detectRerunSemantics()
+
+describe('RxListHost × data0 错误恢复(computation 重跑)', () => {
+    test('rethrow 出口(无 error 钩子):恢复语义按 data0 代际,DOM 始终不崩坏', () => {
+        const list = new RxList<number>([1, 2])
+        let throwFor: number | null = null
+        const Row = ({item}: {item: number}) => {
+            if (item === throwFor) throw new Error('row render boom')
+            return <span>{item}</span>
+        }
+        const root = document.createElement('div')
+        document.body.appendChild(root)
+        const app = createRoot(root)
+        app.render(<div>
+            {list.map(item => <Row item={item}/>)}
+        </div>)
+        expect(root.textContent).toBe('12')
+
+        throwFor = 3
+        expect(() => list.push(3)).toThrow('row render boom')
+        // fail-stop:保留最后一个完整 DOM
+        expect(root.textContent).toBe('12')
+
+        throwFor = null
+        list.push(4)
+        if (HAS_RERUN_RECOVERY) {
+            // data0 >= 2.9:全量恢复 → computation 重跑 → 旧行销毁 + 全量重建。
+            // 修复前:残留 hosts 撞 "should never rerender",这里直接抛错。
+            expect(root.textContent).toBe('1234')
+            expect(root.querySelectorAll('span').length).toBe(4)
+            // 恢复后回到增量
+            list.splice(0, 1)
+            expect(root.textContent).toBe('234')
+        } else {
+            // data0 <= 2.8:抛错批次(3)丢失,后续增量继续应用(已知旧语义)
+            expect(root.textContent).toBe('124')
+        }
+
+        app.destroy()
+        document.body.removeChild(root)
+    })
+
+    test('error 钩子消费出口:错误不经 data0,fail-stop 契约不变(不恢复、不崩坏)', () => {
+        // 对照组:错误被 root error 钩子**消费**时 RxListHost 的 applyPatch 正常返回,
+        // data0 视为 patch 成功——不回退全量阶段、不重跑 computation。恢复责任在
+        // 上层(RxListHost 注释声明的 fail-stop:保留最后一个完整 DOM,后续增量在
+        // 不一致状态上继续,等待上层销毁/恢复)。此行为与 data0 代际无关。
+        const list = new RxList<number>([1, 2])
+        let throwFor: number | null = null
+        const Row = ({item}: {item: number}) => {
+            if (item === throwFor) throw new Error('row render boom')
+            return <span>{item}</span>
+        }
+        const root = document.createElement('div')
+        document.body.appendChild(root)
+        const app = createRoot(root)
+        const errors: unknown[] = []
+        app.on('error', (e: unknown) => { errors.push(e) })
+        app.render(<div>
+            {list.map(item => <Row item={item}/>)}
+        </div>)
+
+        throwFor = 3
+        list.push(3) // 行渲染错误被钩子消费,不上抛
+        expect(errors.length).toBe(1)
+        expect(root.textContent).toBe('12')
+
+        throwFor = null
+        list.push(4)
+        // 抛错批次(3)按 fail-stop 丢失;后续增量仍能应用,系统不崩
+        expect(root.textContent).toBe('124')
+        expect(errors.length).toBe(1) // 无新错误
+
+        app.destroy()
+        document.body.removeChild(root)
+    })
+})

--- a/src/RxListHost.ts
+++ b/src/RxListHost.ts
@@ -117,6 +117,16 @@ export class RxListHost implements Host{
                 this.pauseCollectChild()
                 try {
                     const hosts = host.hosts!
+                    // CAUTION data0 >= 2.9 的错误恢复契约(data0Contract.spec 条款 8):
+                    //  patch 抛错(rethrow 出口)后 data0 把该 computed 回退到全量重算阶段,
+                    //  下一次源变更会**重跑本 computation**(而不是继续 patch)。重跑语义
+                    //  即全量重建:先销毁上一轮的行(自摘 DOM),再按当前 data 重建。
+                    //  旧实现假定 computation 只跑一次,重跑时残留 hosts 会让行组件撞上
+                    //  "should never rerender" 断言,列表区域从此永久崩坏。
+                    if (hosts.length) {
+                        for (const previous of hosts) previous.destroy()
+                        hosts.length = 0
+                    }
                     const data = source.data
                     try {
                         for (let i = 0; i < data.length; i++) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 背景

data0 的 2026-H2 深度 review(data0#9)修复了缺陷类 4 并改变了 patch 错误恢复契约:**patch 抛错(rethrow 出口)后,data0 把该 computed 回退到全量重算阶段——下一次源变更重跑 computation,而不是增量 patch**(抛错批次的 triggerInfos 已被消费、增量态不可信,只重放新 info 会静默分叉)。

## 动态复现的缺陷(对 sibling data0 2.9 checkout)

`RxListHost` 的 computation 假定只跑一次。重跑时残留的 `hosts` 数组被复用:全部行在旧行之上重复创建,行组件撞上 `should never rerender` 断言——**一次已恢复的错误让列表区域永久崩坏**。

## 修复

computation 开头先销毁上一轮 hosts(自摘 DOM)再按当前 data 全量重建。初次渲染不受影响(hosts 为空);data0 ≤ 2.8 从不重跑,守卫惰性。

## 契约资产(双代运行时探测,npm 2.8 与 sibling 2.9 下都绿)

- **`data0Contract.spec` 条款 8 更新**:锁定两代共同不变量(失败批次永不重放),按恢复语义代分支断言(2.8:下一次变更继续增量;2.9+:下一次变更重跑 computation 且 applyPatch 不收 info,再下一次恢复增量);
- **`data0RecoveryRerun.spec`(新)**:端到端回归——rethrow 出口在 2.9+ 恢复为全量重建且 DOM ≡ 数据(未修复时该测试直接撞 `should never rerender`);error 钩子消费出口的 fail-stop 语义不变(错误不经 data0,恢复责任在边界,与 data0 代际无关)。

## 验证

- 全套 671 tests 全绿(sibling data0 2.9);
- 契约相关 spec 在隐藏 sibling(npm data0 2.8)下同样全绿,双代兼容确认。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-964112d3-14d6-43dc-b1b8-e9be584892f0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-964112d3-14d6-43dc-b1b8-e9be584892f0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

