### PR TITLE
fix(RxListHost): use EKC info.newValue under batch multi-info digests

### DIFF
--- a/__tests__/data0Contract.spec.tsx
+++ b/__tests__/data0Contract.spec.tsx
@@ -10,8 +10,10 @@
  * 1. splice 的 argv 是用户传入的原始参数：start 可以是负数、可以越界（Array#splice 语义），
  *    消费方必须自行归一化；methodResult 是真实删除的元素数组（长度即真实删除数）。
  * 2. push/pop/shift/unshift 等便捷方法一律以 splice patch 的形态到达，argv 已换算成索引。
- * 3. set(index, v) 以 EXPLICIT_KEY_CHANGE 到达：key 是 index（数字），methodResult 是旧值。
- *    CAUTION index 越界的 set 会产生稀疏数组，属于契约外用法（由 dev 模式的列表不变量兜底报错）。
+ * 3. set(index, v) 以 EXPLICIT_KEY_CHANGE 到达：key 是 index（数字），newValue 是操作时新值，
+ *    methodResult 是旧值。RxListHost 必须用 newValue 建行，禁止回读 source.data[key]
+ *    （batch 多 info 重放时 source 已是终态）。CAUTION index 越界的 set 会产生稀疏数组，
+ *    属于契约外用法（由 dev 模式的列表不变量兜底报错）。
  * 4. reorder(pairs) 以 method === 'reorder' 到达：argv[0] 是 pairs（语义 data[to] = old[from]），
  *    并携带 reorderInfo（kind/affectedRange），swap/reposition/sortSelf 都收敛到它。
  * 5. 派生列表（map）收到的 patch 形态与源列表一致（axii 渲染 list.map(...) 时依赖这一点）。
@@ -132,7 +134,7 @@ describe('data0 -> axii trigger info contract', () => {
         sub.destroy()
     })
 
-    test('3. set() arrives as EXPLICIT_KEY_CHANGE with numeric key and old value as methodResult', () => {
+    test('3. set() arrives as EXPLICIT_KEY_CHANGE with numeric key, newValue, and old value as methodResult', () => {
         const list = new RxList(['a', 'b', 'c'])
         const sub = captureTriggerInfos(list)
 
@@ -142,6 +144,7 @@ describe('data0 -> axii trigger info contract', () => {
         expect(keyChange).toBeTruthy()
         expect(keyChange.key).toBe(1)
         expect(typeof keyChange.key).toBe('number')
+        expect(keyChange.newValue).toBe('B')
         expect(keyChange.methodResult).toBe('b')
         expect(list.data).toEqual(['a', 'B', 'c'])
 

--- a/__tests__/rxListHost.spec.tsx
+++ b/__tests__/rxListHost.spec.tsx
@@ -1,6 +1,6 @@
 /** @jsx createElement */
 import {ComponentHost, createElement, createRoot, StaticHost} from "@framework";
-import {atom, RxList, RxMap} from "data0";
+import {atom, batch, RxList, RxMap} from "data0";
 import {beforeEach, describe, expect, test} from "vitest";
 import {RxListHost} from "../src/RxListHost";
 
@@ -292,6 +292,30 @@ describe('rxList render', () => {
 
         arr.swap(0, 2)
         expect(rootEl.children[0].innerHTML).toBe('a')
+    })
+
+    test('batch set+splice: EKC must use info.newValue (not source.data[key])', () => {
+        // data0 multi-info digest: EKC key is operation-time index while source.data
+        // is final state. Reading source.data[key] after set(1,'X')+splice(0,1)
+        // yields the wrong row and permanently desyncs hosts from data.
+        const arr = new RxList(['a', 'b', 'c'])
+
+        function App() {
+            return <div>
+                {arr.map((item) => <span>{item}</span>)}
+            </div>
+        }
+
+        root.render(<App/>)
+        expect([...rootEl.firstElementChild!.children].map(el => el.innerHTML)).toEqual(['a', 'b', 'c'])
+
+        batch(() => {
+            arr.set(1, 'X')
+            arr.splice(0, 1)
+        })
+
+        expect(arr.data).toEqual(['X', 'c'])
+        expect([...rootEl.firstElementChild!.children].map(el => el.innerHTML)).toEqual(['X', 'c'])
     })
 
 })

--- a/src/RxListHost.ts
+++ b/src/RxListHost.ts
@@ -283,7 +283,10 @@ export class RxListHost implements Host{
         } else if(method === 'reorder') {
             this.handleReorder(argv![0], (info as any).reorderInfo)
         } else if(type === TriggerOpTypes.EXPLICIT_KEY_CHANGE) {
-            this.handleExplicitKeyChange(key as number)
+            // CAUTION 必须传 info.newValue（操作时的值），不能在 handler 里回读
+            //  source.data[key]：key 是操作时位置，source.data 是重放时终态——
+            //  batch 内 set+splice 时终态下标上已是别的元素（data0 RxList.map 同款注释）。
+            this.handleExplicitKeyChange(key as number, info.newValue)
           /* v8 ignore next 3 */
         } else {
             throw new Error('unknown trigger info')
@@ -423,7 +426,7 @@ export class RxListHost implements Host{
             anchor = childHost.element
         }
     }
-    handleExplicitKeyChange(index: number) {
+    handleExplicitKeyChange(index: number, newValue: any) {
         const hosts = this.hosts!
         // data0 的 set(index, value) 可以像数组赋值一样扩大 length，但 RxListHost 的
         // 增量替换契约只支持已有稠密索引。必须在销毁旧行/写 hosts[index] 之前拒绝，
@@ -439,7 +442,7 @@ export class RxListHost implements Host{
         const oldHost = hosts[index]
         oldHost.destroy()
 
-        const newHost = this.createChildHost(this.source.data[index])
+        const newHost = this.createChildHost(newValue)
         hosts[index] = newHost
         // compact host 没有独立占位符，直接定位元素本身
         const newHostAnchorNode = newHost instanceof CompactElementHost ? newHost.element : newHost.placeholder


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`RxListHost.handleExplicitKeyChange` previously built the replacement row from `this.source.data[index]`. Under a data0 multi-info digest (e.g. `batch(() => { list.set(1, 'X'); list.splice(0, 1) })`), the EKC key is the **operation-time** index while `source.data` is already the **final** state — so the host reads the wrong value and permanently desyncs from data.

This matches the CAUTION already in data0's own `RxList.map` patch path: consume `info.newValue`.

## Evidence

- [x] Dynamically reproduced: `batch { set(1,'X'); splice(0,1) }` left DOM as `['c','c']` (or similar wrong pair) while `list.data === ['X','c']` before the fix; after fix both match `['X','c']`.
- [x] The reproduction failed before the fix and passes after it.

## Verification

- [x] `npx vitest run` — 53 files / 672 tests passed
- [x] Regression: `__tests__/rxListHost.spec.tsx` batch set+splice case
- [x] Contract: `__tests__/data0Contract.spec.tsx` now pins `keyChange.newValue`

Related: axiijs/data0#11 (documents the consumer contract), axiijs/axle companion PR.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-80ec7382-8a39-4c13-9dc5-0f7cffc4010b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-80ec7382-8a39-4c13-9dc5-0f7cffc4010b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

