### PR TITLE
docs(agents): clarify sibling data0/src resolution in combined workspace

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,7 +12,7 @@ Services / commands (see `package.json` scripts):
 Gotchas:
 - Browser tests need the Playwright chromium browser **and** its system libraries. The update script runs `npx playwright install chromium`, but the OS libraries (`--with-deps`, needs sudo) are part of the base image, not the update script.
 - There is no lint script. `npx tsc --noEmit -p tsconfig.json` reports **pre-existing** errors in `__tests__/*.typespec.tsx` and a few spec files; it is not wired into `build` (which uses `vite-plugin-dts`) or CI. Rely on `npm run build` + `npx vitest run` as the quality gates.
-- `data0` (the reactive core) resolves from the npm-installed package unless a sibling `../data0/src` checkout exists (see `vite.config.ts`); no sibling checkout is present here.
+- `data0` (the reactive core) resolves from the npm-installed package unless a sibling `../data0/src` checkout exists (the alias is applied in `vitest.config.ts`; it is commented out in `vite.config.ts`). When `axii`, `data0`, and `axle` are checked out side by side (as in the combined `axiijs` workspace), `npx vitest run` runs against `../data0/src` directly, so edits to `data0` source are picked up live without rebuilding/reinstalling.
 
 ## Performance is a core goal
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

While setting up the development environment for the combined `axiijs` workspace (`axii` + `data0` + `axle` checked out side by side), I found the `## Cursor Cloud specific instructions` note about `data0` resolution was inaccurate for that layout:

- It said "no sibling checkout is present here" — but when the repos are checked out together, a sibling `../data0/src` **is** present, and `npx vitest run` resolves `data0` from source.
- The sibling alias is actually applied in `vitest.config.ts` (it is commented out in `vite.config.ts`), so the previous file reference was misleading.

This is a docs-only change (one line in `AGENTS.md`); no code behavior changes.

## Testing

Environment was fully validated during setup (unchanged by this doc edit):
- `npm run build` — ✅ emits `dist/`
- `npx vitest run` — ✅ 672 browser tests pass (real chromium via Playwright)
- `npx vitest run --config vitest.node.config.ts` — ✅ 6 node tests pass

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fe1933f1-afcc-4909-8218-d619f886e590"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fe1933f1-afcc-4909-8218-d619f886e590"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

