### PR TITLE
chore(deps): bump data0 to ^2.14.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "@types/node": "^22.9.3",
     "@vitest/browser": "^3.2.4",
     "@vitest/coverage-v8": "^3.2.4",
-    "data0": "^2.13.0",
+    "data0": "^2.14.0",
     "release-it": "^19.0.4",
     "typescript": "5.9.2",
     "vite": "^7.1.1",
@@ -61,7 +61,7 @@
     "vitest": "^3.2.4"
   },
   "peerDependencies": {
-    "data0": "^2.13.0"
+    "data0": "^2.14.0"
   },
   "release-it": {
     "plugins": {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

跟进 data0 2.14.0(round-7 深度 review,[axiijs/data0#18](https://github.com/axiijs/data0/pull/18)):

- 用户钩子(onRecompute/onCleanup/context.onCleanup 清理)抛错不再永久卡死 computed 状态机——axii FunctionHost 把 context.onCleanup 直接暴露给用户渲染函数,该修复对 axii 现实可达;
- async 收尾阶段(订阅者派发/回退重算)的错误不再变成 unhandled rejection,cleanPromise 照常 settle;
- reorder 协议载荷深拷到 Order 对一层(调用方复用 order 数组不再毒化派生);
- RxSet.toList × replace 顺序对齐全量重算;destroyComputed/recompute 直接接受 Rx 结构;destroy 后惰性 meta 首读不再泄漏活 effect。

dependencies 变化:devDependencies 与 peerDependencies 的 `data0` 均 `^2.13.0` → `^2.14.0`。

## Verification

- axii 全套 53 files / 672 tests 对 **npm 安装的 data0@2.14.0 真实产物**(临时关闭 sibling alias)全绿,`EXIT=0`;
- 此前 review 过程中亦以 sibling alias 对同一 src 全绿两轮。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7bcf5264-ad82-4194-aedb-7cbcf0bd3edb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7bcf5264-ad82-4194-aedb-7cbcf0bd3edb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

