### PR TITLE
bump data0 to ^2.15.0 (round-8 review fixes)

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "@types/node": "^22.9.3",
     "@vitest/browser": "^3.2.4",
     "@vitest/coverage-v8": "^3.2.4",
-    "data0": "^2.14.0",
+    "data0": "^2.15.0",
     "release-it": "^19.0.4",
     "typescript": "5.9.2",
     "vite": "^7.1.1",
@@ -61,7 +61,7 @@
     "vitest": "^3.2.4"
   },
   "peerDependencies": {
-    "data0": "^2.14.0"
+    "data0": "^2.15.0"
   },
   "release-it": {
     "plugins": {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

将 data0 升级到 ^2.15.0(deps + peerDependencies),携带 round-8 深度 review 的九项修复:

- `filter` × truthy 非布尔谓词的存储点布尔化(行级重跑误判首跑 → 重复插行/永不移除/插错位置);
- 观察出口(`onChange`/自定义调度器)载荷按协议形状拷贝:reorder pair 与 `reorderInfo` 深拷、数组型用户值保引用身份;
- `indexBy`/`toMap` 重复 key 守卫全入口对称(EKC/splice 插入侧曾静默覆盖);
- `map` 行级重算前执行上一轮 `context.onCleanup`(与 computed 语义对齐);
- `RxSet.forEach` track 先于迭代(handler 抛错不再永久丢订阅);
- `swap` 重叠区间 loud-fail、公开 `reorder` 的 dev 置换校验;
- batch 内非收敛环的 dev 诊断、async getter warn 每实例一次。

## Verification

- axii 全套测试对升级后依赖全绿:53 文件 672 tests(vitest browser mode,sibling data0 与 npm 2.15.0 同源)。
- data0 侧下游反向确认在发版前已做(见 axiijs/data0#19)。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2d7bd0e2-f951-4117-9542-81056d40fa9d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2d7bd0e2-f951-4117-9542-81056d40fa9d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

